### PR TITLE
Fix repligit example

### DIFF
--- a/examples/git_mirror.py
+++ b/examples/git_mirror.py
@@ -1,4 +1,4 @@
-from repligit import ls_remote, fetch_pack, send_pack
+from repligit.repligit import ls_remote, fetch_pack, send_pack
 
 
 def main():
@@ -9,6 +9,7 @@ def main():
 
     target_ref = f"refs/heads/{branch_name}"
 
+    # if either src or dest require auth for read access, add the username and password args
     gh_refs = ls_remote(src_remote_url)
     gl_refs = ls_remote(dest_remote_url)
 


### PR DESCRIPTION
Corrected module import to `repligit.repligit` and added some clarifications re: auth

If we want to keep `from repligit import *`, we'd have to change `src/__init__.py` to:

```
from repligit.repligit import ls_remote, fetch_pack, send_pack

__all__ = ["ls_remote", "fetch_pack", "send_pack", "repligit"]
```