### PR TITLE
ci: add codespell and decrease max line length

### DIFF
--- a/.github/workflows/requirements/style.txt
+++ b/.github/workflows/requirements/style.txt
@@ -1,1 +1,2 @@
 ruff==0.11.2
+codespell==2.4.1

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -21,12 +21,12 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -r .github/workflows/requirements/style.txt
-      # Update output format to enable automatic inline annotations.
+
       - name: Run Ruff
         run: |
           ruff check --output-format=github
-          ruff check --select I --fix
+          ruff check --select I --output-format=github
           ruff format --check --diff
-          
+
       - name: Run Codespell
         run: codespell

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -24,10 +24,8 @@ jobs:
       # Update output format to enable automatic inline annotations.
       - name: Run Ruff
         run: |
-          echo "---------- Ruff Checks ----------"
           ruff check --output-format=github
           ruff format --check --diff
-          echo "---------------------------------"
-          echo "----------- Codespell -----------"
-          codespell
-          echo "---------------------------------"
+          
+      - name: Run Codespell
+        run: codespell

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -25,6 +25,7 @@ jobs:
       - name: Run Ruff
         run: |
           ruff check --output-format=github
+          ruff check --select I --fix
           ruff format --check --diff
           
       - name: Run Codespell

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Run Ruff
         run: |
-          ruff check --output-format=github
-          ruff check --select I --output-format=github
+          ruff check --diff
+          ruff check --select I --diff
           ruff format --check --diff
 
       - name: Run Codespell

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -24,6 +24,10 @@ jobs:
       # Update output format to enable automatic inline annotations.
       - name: Run Ruff
         run: |
+          echo "---------- Ruff Checks ----------"
           ruff check --output-format=github
           ruff format --check --diff
+          echo "---------------------------------"
+          echo "----------- Codespell -----------"
           codespell
+          echo "---------------------------------"

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -23,4 +23,7 @@ jobs:
           pip install -r .github/workflows/requirements/style.txt
       # Update output format to enable automatic inline annotations.
       - name: Run Ruff
-        run: ruff check --output-format=github src
+        run: |
+          ruff check --output-format=github
+          ruff format --check --diff
+          codespell

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ GitLab for secure CI/CD on local hardware.
 
 ## License
 
-Licensed under the Apache License, Version 2.0 w/LLVM Execption
+Licensed under the Apache License, Version 2.0 w/LLVM Exception
 (the "License"); you may not use this file except in compliance
 with the License. You may obtain a copy of the License at
 

--- a/examples/git_mirror.py
+++ b/examples/git_mirror.py
@@ -1,4 +1,4 @@
-from repligit import ls_remote, fetch_pack, send_pack
+from repligit import fetch_pack, ls_remote, send_pack
 
 
 def main():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,4 +31,4 @@ pythonpath = [
 ]
 
 [tool.ruff]
-line-length = 99
+line-length = 88

--- a/spack.yaml
+++ b/spack.yaml
@@ -5,11 +5,12 @@
 spack:
   # add package specs to the `specs` list
   specs:
-  - py-requests
-  - python
+  - py-codespell
   - py-pip
   - py-pytest
+  - py-requests
   - py-ruff
+  - python
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
Adding codespell to help fix my bad spelling, lowered the max line length to allow two emacs buffers next to each other.

Also modified the ruff call to also check for linting and formatting across both src and examples.