### PR TITLE
Drop requests as a dependency of repligit's synchronous implementation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,9 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "repligit"
 version = "0.0.1"
-dependencies = [
-  "requests"
-]
+dependencies = []
 authors = [
   { name="Alec Scott", email="alec@llnl.gov" },
 ]

--- a/spack.yaml
+++ b/spack.yaml
@@ -11,7 +11,7 @@ spack:
   - py-pytest
   - py-repligit
   - py-ruff
-  - py-aiohttp
+  - py-pip
   - python
   view: true
   concretizer:

--- a/spack/repo/packages/py-repligit/package.py
+++ b/spack/repo/packages/py-repligit/package.py
@@ -21,5 +21,4 @@ class PyRepligit(PythonPackage):
 
     depends_on("py-hatchling", type="build")
 
-    depends_on("py-requests", type=("build", "run"))
     depends_on("py-aiohttp", type=("build", "run"), when="+aiohttp")

--- a/src/repligit/client.py
+++ b/src/repligit/client.py
@@ -1,12 +1,11 @@
+import urllib.request
 from typing import List
 
-import urllib.request
-
 from repligit.parse import (
-    iter_lines,
     decode_lines,
     generate_fetch_pack_request,
     generate_send_pack_header,
+    iter_lines,
 )
 
 

--- a/src/repligit/client.py
+++ b/src/repligit/client.py
@@ -1,12 +1,43 @@
 from typing import List
 
-import requests
+import urllib.request
 
 from repligit.parse import (
+    iter_lines,
     decode_lines,
     generate_fetch_pack_request,
     generate_send_pack_header,
 )
+
+
+def http_request(url, headers=None, username=None, password=None, data=None):
+    """
+    Constructs and executes an HTTP request using urllib. (GET by default,
+    POST if "data" is not None).
+
+    Args:
+        url (str): The URL to send the request to
+        headers (dict, optional): HTTP headers to include in the request
+        username (str, optional): Username for basic authentication
+        password (str, optional): Password for basic authentication
+        data (bytes, optional): Data to send in the request body
+
+    Returns:
+        file-like object: The response file handler from the request
+    """
+    password_manager = urllib.request.HTTPPasswordMgrWithDefaultRealm()
+    password_manager.add_password(None, url, username, password)
+
+    auth_handler = urllib.request.HTTPBasicAuthHandler(password_manager)
+    opener = urllib.request.build_opener(auth_handler)
+
+    request = urllib.request.Request(url, data=data)
+
+    if headers:
+        for header, value in headers.items():
+            request.add_header(header, value)
+
+    return opener.open(request)
 
 
 def ls_remote(url: str, username: str = None, password: str = None):
@@ -14,15 +45,10 @@ def ls_remote(url: str, username: str = None, password: str = None):
     None if no remote commits.
     """
     url = f"{url}/info/refs?service=git-upload-pack"
-    auth = (username, password) if username or password else None
 
-    resp = requests.get(url, stream=True, auth=auth)
-    resp.raise_for_status()
+    resp = http_request(url, username=username, password=password)
 
-    if resp.encoding is None:
-        resp.encoding = "utf-8"
-
-    lines = decode_lines(resp.iter_lines(decode_unicode=True))
+    lines = decode_lines(iter_lines(resp))
     service_line = next(lines)
     assert service_line == "# service=git-upload-pack"
 
@@ -34,27 +60,23 @@ def fetch_pack(
 ):
     """Download a packfile from a remote server."""
     url = f"{url}/git-upload-pack"
-    auth = (username, password) if username or password else None
-
     request = generate_fetch_pack_request(want_sha, have_shas)
 
-    resp = requests.post(
+    resp = http_request(
         url,
         headers={
             "Content-type": "application/x-git-upload-pack-request",
         },
-        auth=auth,
+        username=username,
+        password=password,
         data=request,
-        stream=True,
-        timeout=None,
     )
-    resp.raise_for_status()
 
-    line_length = int(resp.raw.read(4), 16)
-    line = resp.raw.read(line_length - 4)
+    line_length = int(resp.read(4), 16)
+    line = resp.read(line_length - 4)
 
     if line[:3] == b"NAK" or line[:3] == b"ACK":
-        return resp.raw
+        return resp
     else:
         return None
 
@@ -70,25 +92,20 @@ def send_pack(
 ):
     """Send a packfile to a remote server."""
     url = f"{url}/git-receive-pack"
-    auth = (username, password) if username or password else None
 
     header = generate_send_pack_header(ref, from_sha, to_sha)
     receive_pack_request = header + packfile.read()
 
-    resp = requests.post(
+    resp = http_request(
         url,
         headers={
             "Content-type": "application/x-git-receive-pack-request",
         },
-        stream=True,
-        auth=auth,
+        username=username,
+        password=password,
         data=receive_pack_request,
     )
-    resp.raise_for_status()
 
-    if resp.encoding is None:
-        resp.encoding = "utf-8"
-
-    lines = decode_lines(resp.iter_lines(decode_unicode=True))
+    lines = decode_lines(iter_lines(resp))
     assert next(lines) == "unpack ok"
     assert next(lines) == f"ok {ref}"

--- a/src/repligit/parse.py
+++ b/src/repligit/parse.py
@@ -1,4 +1,4 @@
-from typing import Generator, List, Union, IO
+from typing import IO, Generator, List, Union
 
 
 def iter_lines(

--- a/src/repligit/parse.py
+++ b/src/repligit/parse.py
@@ -34,6 +34,10 @@ def decode_lines(lines: Generator[str]) -> Generator[str]:
     """
     Decode lines from the git transfer protocol into usable lines.
 
+    This asynchronous function processes a stream of lines from a server response,
+    where each line is prefixed with a 4-character hexadecimal length indicator.
+    It extracts and yields the actual data portion of each line.
+
     Args:
         lines: A generator yielding strings from a git server response.
 

--- a/src/repligit/parse.py
+++ b/src/repligit/parse.py
@@ -1,16 +1,60 @@
-# --------- shared client helpers ---------
-from typing import Generator, List, Union
+from typing import Generator, List, Union, IO
+
+
+def iter_lines(
+    data: IO, encoding: str = "utf-8", chunk_size: int = 16 * 1024
+) -> Generator[str]:
+    """
+    Iterate over the lines of a file-like object, yielding one line at a time.
+
+    Args:
+        data: A file-like object with a read() method that returns bytes
+        encoding (str, optional): Character encoding to use for decoding bytes to strings.
+            Defaults to "utf-8".
+        chunk_size (int, optional): Number of bytes to read in each chunk.
+            Defaults to 16 KiB.
+
+    Yields:
+        str: Each line from the input data, with line endings removed.
+    """
+    incomplete_line = bytearray()
+
+    for chunk in iter(lambda: data.read(chunk_size), b""):
+        lines = (incomplete_line + chunk).split(b"\n")
+        incomplete_line = lines.pop()
+
+        for line in lines:
+            yield line.rstrip(b"\r").decode(encoding)
+
+    if incomplete_line:
+        yield incomplete_line.rstrip(b"\r").decode(encoding)
 
 
 def decode_lines(lines: Generator[str]) -> Generator[str]:
-    """Decode server response iterator into usable lines."""
+    """
+    Decode lines from the git transfer protocol into usable lines.
+
+    Args:
+        lines: A generator yielding strings from a git server response.
+
+    Yields:
+        str: Decoded content from each line with the length prefix removed.
+    """
     for line in lines:
         line_length = int(line[:4], 16)
         yield line[4:line_length]
 
 
 def encode_lines(lines: List[Union[bytes, str]]) -> bytes:
-    """Build byte string from given lines to send to server."""
+    """
+    Encode a list of lines into a byte string format for git transmission.
+
+    Args:
+        lines: A list of strings or byte objects to be encoded.
+
+    Returns:
+        bytes: A single byte string containing all encoded lines.
+    """
     result = []
     for line in lines:
         if type(line) is str:
@@ -24,12 +68,30 @@ def encode_lines(lines: List[Union[bytes, str]]) -> bytes:
 
 
 def generate_send_pack_header(ref: str, from_sha: str, to_sha: str) -> bytes:
+    """
+    Generate a Git send-pack header for updating references.
+
+    Args:
+        ref (str): The full reference name (e.g., 'refs/heads/main')
+        from_sha (str): The source SHA-1 object ID (40 hex characters)
+        to_sha (str): The target SHA-1 object ID (40 hex characters)
+
+    Returns:
+        bytes: Encoded pack header with the format "<from_sha> <to_sha> <ref>\0 report-status"
+               followed by the "0000" flush packet
+    """
     return encode_lines([f"{from_sha} {to_sha} {ref}\x00 report-status"]) + b"0000"
 
 
 def generate_fetch_pack_request(want: str, haves: List[str]) -> bytes:
-    """Generate a git-upload packfile request to retrieve a packfile from a
-    remote server based on a list of have and want commits.
+    """Generate a git-upload packfile request.
+
+    Args:
+        want (str): The SHA-1 hash of the commit that is wanted.
+        haves (List[str]): A list of SHA-1 hashes of commits that the client already has.
+
+    Returns:
+        bytes: The formatted git-upload-pack request as bytes.
     """
     want_cmds = encode_lines([f"want {want}".encode()])
     have_cmds = encode_lines([f"have {sha}".encode() for sha in haves])


### PR DESCRIPTION
Dropped our dependency on `requests` for the synchronous implementation of repligit!

Closes #3.