### PR TITLE
asyncio: update iter_lines to follow sync method logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,12 +32,13 @@ jobs:
         with:
           filters: |
             style:
-              - '.github/**'
-              - 'src/**'
+              - '.github/**/*'
+              - 'src/**/*'
               - 'pyproject.toml'
             unit-tests:
-              - '.github/**'
-              - 'tests/**'
+              - '.github/**/*'
+              - 'src/**/*'
+              - 'tests/**/*'
               - 'pyproject.toml'
 
   style:

--- a/src/repligit/asyncio/parse.py
+++ b/src/repligit/asyncio/parse.py
@@ -44,7 +44,7 @@ async def iter_lines(
         lines = (incomplete_line + chunk).split(b"\n")
         incomplete_line = lines.pop()
 
-        async for line in lines:
+        for line in lines:
             yield line.rstrip(b"\r").decode(encoding)
 
     if incomplete_line:

--- a/src/repligit/asyncio/parse.py
+++ b/src/repligit/asyncio/parse.py
@@ -1,38 +1,51 @@
-# --------- asynchronous client helpers ---------
 from typing import AsyncIterable, AsyncIterator
 
 import aiohttp
 
 
 async def decode_lines(line_stream: AsyncIterable) -> AsyncIterator:
-    """(async) Decode server response iterator into usable lines."""
+    """Decode git server response iterator into individual data lines.
+
+    This asynchronous function processes a stream of lines from a server response,
+    where each line is prefixed with a 4-character hexadecimal length indicator.
+    It extracts and yields the actual data portion of each line.
+
+    Args:
+        line_stream: An asynchronous iterable providing the raw server response lines.
+
+    Yields:
+        The decoded data portion of each line, with the length prefix removed.
+    """
     async for line in line_stream:
         line_length = int(line[:4], 16)
         yield line[4:line_length]
 
 
 async def iter_lines(
-    resp: aiohttp.ClientResponse, encoding: str, chunk_size: int = 512
+    resp: aiohttp.ClientResponse, encoding: str = "utf-8", chunk_size: int = 16 * 1024
 ):
     """
-    Stream lines from an HTTP response. Yields raw lines as bytes by default.
+    Asynchronously iterate over the lines of an HTTP response.
 
-    If `encoding` is set, yields decoded strings using the given encoding.
+    Args:
+        resp: The aiohttp ClientResponse object to read from.
+        encoding: The character encoding to use for decoding bytes to strings.
+            Defaults to "utf-8".
+        chunk_size: The number of bytes to read in each chunk.
+            Defaults to 16 KiB (16 * 1024 bytes).
 
-    This is a reimplementation of requests.models.iter_lines for async,
-    the default `chunk_size` value is inherited from that definition.
+    Yields:
+        str: Each line from the response, with trailing carriage returns removed
+            and decoded using the specified encoding.
     """
-    buffer = bytearray()
+    incomplete_line = bytearray()
 
     async for chunk in resp.content.iter_chunked(chunk_size):
-        buffer.extend(chunk)
-        while b"\n" in buffer:
-            idx = buffer.index(b"\n")
-            line = buffer[:idx].rstrip(b"\r")
-            del buffer[: idx + 1]
-            yield line.decode(encoding) if encoding else bytes(line)
+        lines = (incomplete_line + chunk).split(b"\n")
+        incomplete_line = lines.pop()
 
-    # if there's anything left in the response yield it
-    if buffer:
-        line = buffer.rstrip(b"\r")
-        yield line.decode(encoding) if encoding else bytes(line)
+        async for line in lines:
+            yield line.rstrip(b"\r").decode(encoding)
+
+    if incomplete_line:
+        yield incomplete_line.rstrip(b"\r").decode(encoding)


### PR DESCRIPTION
In rewriting the synchronous `iter_lines()` method a few times I think I came on something a bit more uniform between the two that might help in reducing the divergence and troubleshooting later on.