### PR TITLE
Fix Generator type hints for python 3.10 -> 3.12

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.10', '3.13']
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
       - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55

--- a/spack.yaml
+++ b/spack.yaml
@@ -12,7 +12,7 @@ spack:
   - py-repligit
   - py-ruff
   - py-pip
-  - python
+  - python@3.10
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -12,7 +12,7 @@ spack:
   - py-repligit
   - py-ruff
   - py-pip
-  - python@3.10
+  - "python@3.10:"
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -12,7 +12,6 @@ spack:
   - py-repligit
   - py-ruff
   - py-pip
-  - "python@3.10:"
   view: true
   concretizer:
     unify: true

--- a/src/repligit/parse.py
+++ b/src/repligit/parse.py
@@ -3,7 +3,7 @@ from typing import IO, Generator, List, Union
 
 def iter_lines(
     data: IO, encoding: str = "utf-8", chunk_size: int = 16 * 1024
-) -> Generator[str]:
+) -> Generator[str, str, str]:
     """
     Iterate over the lines of a file-like object, yielding one line at a time.
 
@@ -30,7 +30,7 @@ def iter_lines(
         yield incomplete_line.rstrip(b"\r").decode(encoding)
 
 
-def decode_lines(lines: Generator[str]) -> Generator[str]:
+def decode_lines(lines: Generator[str, str, str]) -> Generator[str, str, str]:
     """
     Decode lines from the git transfer protocol into usable lines.
 


### PR DESCRIPTION
Technically Repligit doesn't require anything special about Python 3.13, but we'd used the newer type hinting which broke older versions. This fixes those type hints to be compatible back to 3.10.