### PR TITLE
ci: add security checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 concurrency:
   group: ci-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
   cancel-in-progress: true
@@ -14,10 +17,9 @@ concurrency:
 jobs:
   changes:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
     outputs:
       style: ${{ steps.filter.outputs.style }}
+      security: ${{ steps.filter.outputs.security }}
       unit-tests: ${{ steps.filter.outputs.unit-tests }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # @v2
@@ -34,6 +36,11 @@ jobs:
               - '.github/**/*'
               - 'src/**/*'
               - 'pyproject.toml'
+            security:
+              - '.github/**/*'
+              - 'src/**/*'
+              - 'pyproject.toml'
+              - '.bandit'
             unit-tests:
               - '.github/**/*'
               - 'src/**/*'
@@ -44,6 +51,14 @@ jobs:
     if: ${{ needs.changes.outputs.style == 'true' }}
     needs: changes
     uses: ./.github/workflows/style.yml
+
+  security:
+    if: ${{ needs.changes.outputs.security == 'true' }}
+    needs: [changes, style]
+    uses: ./.github/workflows/security.yml
+    permissions:
+      contents: read
+      security-events: write
 
   unit-tests:
     if: ${{ needs.changes.outputs.unit-tests == 'true' }}
@@ -59,6 +74,7 @@ jobs:
     needs:
      - changes
      - style
+     - security
      - unit-tests
      - coverage
     if: always()
@@ -66,7 +82,7 @@ jobs:
     steps:
     - name: Status summary
       run: |
-        if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+        if ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}; then
           echo "One or more required jobs failed or were cancelled"
           exit 1
         else

--- a/.github/workflows/requirements/security.txt
+++ b/.github/workflows/requirements/security.txt
@@ -1,0 +1,1 @@
+bandit[sarif,toml]==1.8.6

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,57 @@
+name: Security Checks
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  bandit-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+      # https://bandit.readthedocs.io/en/latest/faq.html#under-which-version-of-python-should-i-install-bandit
+      - name: Set up Python 3.10
+        uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55
+        with:
+          python-version: '3.10'
+          cache: 'pip'
+          cache-dependency-path: '.github/workflows/requirements/security.txt'
+
+      - name: Install Python dependencies
+        run: pip install -r .github/workflows/requirements/security.txt
+
+      - name: Run Bandit
+        run: bandit -c pyproject.toml -r src -f sarif -o results.sarif
+
+      # upload security results to github; a bot will add inline comments to
+      # the PR if any issues are found
+      - name: Upload SARIF file
+        if: always()
+        uses: github/codeql-action/upload-sarif@3c3833e0f8c1c83d449a7478aa59c036a9165498
+        with:
+          sarif_file: results.sarif
+          category: bandit
+
+  codeql-analyze:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, python]
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@3c3833e0f8c1c83d449a7478aa59c036a9165498
+      with:
+        languages: ${{ matrix.language }}
+        build-mode: none
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@3c3833e0f8c1c83d449a7478aa59c036a9165498
+      with:
+        category: "/language:${{matrix.language}}"

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -1,9 +1,9 @@
 name: Linting & Style Checks
 on:
-  # This Workflow can be triggered manually
-  workflow_dispatch:
   workflow_call:
 
+permissions:
+  contents: read
 
 jobs:
   lint:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,8 +1,9 @@
 name: Unit Tests
 on:
-  # This Workflow can be triggered manually
-  workflow_dispatch:
   workflow_call:
+
+permissions:
+  contents: read
 
 jobs:
   ubuntu:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,3 +37,5 @@ exclude = ["spack"]
 
 [tool.bandit]
 exclude_dirs = []
+# allow use of assert
+skips = ["B101"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,3 +34,6 @@ pythonpath = [
 [tool.ruff]
 line-length = 88
 exclude = ["spack"]
+
+[tool.bandit]
+exclude_dirs = []

--- a/spack/spack.yaml
+++ b/spack/spack.yaml
@@ -10,6 +10,7 @@ spack:
   - py-codespell
   - py-pytest
   - py-repligit
+  - py-bandit
   - py-ruff
   - py-pip
   view: true


### PR DESCRIPTION
replica of https://github.com/LLNL/hubcast/pull/167 and https://github.com/LLNL/hubcast/pull/169:

- adds Bandit (Python static security analysis) check to each PR
- enables GitHub's CodeQL feature
- adds permissions blocks to existing workflows