### PR TITLE
client: ensure have_shas is a set

### DIFF
--- a/src/repligit/asyncio/client.py
+++ b/src/repligit/asyncio/client.py
@@ -33,6 +33,10 @@ async def fetch_pack(
     url: str, want_sha: str, have_shas: Set[str], username=None, password=None
 ):
     """Download a packfile from a remote server."""
+    # ensure have_shas is a set, else packfile errors will occur
+    if not isinstance(have_shas, set):
+        have_shas = set(have_shas)
+
     url = f"{url}/git-upload-pack"
     auth = aiohttp.BasicAuth(username, password) if username or password else None
 

--- a/src/repligit/client.py
+++ b/src/repligit/client.py
@@ -58,6 +58,10 @@ def fetch_pack(
     url: str, want_sha: str, have_shas: Set[str], username=None, password=None
 ):
     """Download a packfile from a remote server."""
+    # ensure have_shas is a set, else packfile errors will occur
+    if not isinstance(have_shas, set):
+        have_shas = set(have_shas)
+
     url = f"{url}/git-upload-pack"
     request = generate_fetch_pack_request(want_sha, have_shas)
 


### PR DESCRIPTION
Ensure that `have_shas` is a set since the Python runtime does't enforce time annotations.