### PR TITLE
Detect send_pack ref update rejections

### DIFF
--- a/src/repligit/asyncio/client.py
+++ b/src/repligit/asyncio/client.py
@@ -96,5 +96,12 @@ async def send_pack(
             raise_for_status=True,
         ) as resp:
             lines = decode_lines(iter_lines(resp, encoding="utf-8"))
-            assert await anext(lines) == "unpack ok"
-            assert await anext(lines) == f"ok {ref}"
+            line1 = await anext(lines)
+            line2 = await anext(lines)
+            assert line1 == "unpack ok"
+
+            # ng = not good, ref update rejected
+            if line2 == f"ng {ref} pre-receive hook declined":
+                raise Exception("pre-receive hook declined")
+
+            assert line2 == f"ok {ref}"

--- a/src/repligit/asyncio/client.py
+++ b/src/repligit/asyncio/client.py
@@ -96,10 +96,9 @@ async def send_pack(
             raise_for_status=True,
         ) as resp:
             lines = decode_lines(iter_lines(resp, encoding="utf-8"))
-            line1 = await anext(lines)
-            line2 = await anext(lines)
-            assert line1 == "unpack ok"
+            assert await anext(lines) == "unpack ok"
 
+            line2 = await anext(lines)
             # ng = not good, ref update rejected
             if line2 == f"ng {ref} pre-receive hook declined":
                 raise Exception("pre-receive hook declined")

--- a/src/repligit/client.py
+++ b/src/repligit/client.py
@@ -124,5 +124,12 @@ def send_pack(
     )
 
     lines = decode_lines(iter_lines(resp))
-    assert next(lines) == "unpack ok"
-    assert next(lines) == f"ok {ref}"
+    line1 = next(lines)
+    line2 = next(lines)
+    assert line1 == "unpack ok"
+
+    # ng = not good, ref update rejected
+    if line2 == f"ng {ref} pre-receive hook declined":
+        raise Exception("pre-receive hook declined")
+
+    assert line2 == f"ok {ref}"

--- a/src/repligit/client.py
+++ b/src/repligit/client.py
@@ -124,10 +124,9 @@ def send_pack(
     )
 
     lines = decode_lines(iter_lines(resp))
-    line1 = next(lines)
-    line2 = next(lines)
-    assert line1 == "unpack ok"
+    assert next(lines) == "unpack ok"
 
+    line2 = next(lines)
     # ng = not good, ref update rejected
     if line2 == f"ng {ref} pre-receive hook declined":
         raise Exception("pre-receive hook declined")


### PR DESCRIPTION
`send_pack` will fail sometimes when the destination repo enables protected branches or other filters that block pushes. This will make the caller aware of the error so they can act accordingly.

Should we create a custom exception for this?