### PR TITLE
Bump codeql actions together since their config is tightly coupled

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+    groups:
+      codeql:
+        patterns:
+          - "github/codeql-action*"
 
   - package-ecosystem: "pip"
     directory: "/.github/workflows/requirements"


### PR DESCRIPTION
I noticed that #193 and #195 failed since dependabot bumped the two actions independently due to a tight coupling on generated config from init to analyze.