### PR TITLE
Add exceptions for common repligit errors

### DIFF
--- a/src/repligit/asyncio/client.py
+++ b/src/repligit/asyncio/client.py
@@ -3,7 +3,13 @@ from typing import Iterable
 import aiohttp
 
 from repligit.asyncio.parse import decode_lines, iter_lines
-from repligit.exceptions import HOOK_DECLINED_MSG, RefUpdateRejected
+from repligit.exceptions import (
+    HOOK_DECLINED_MSG,
+    RefUpdateRejected,
+    RemoteError,
+    UnexpectedResponse,
+    UnpackFailed,
+)
 from repligit.parse import generate_fetch_pack_request, generate_send_pack_header
 
 
@@ -20,7 +26,8 @@ async def ls_remote(
         async with session.get(url, raise_for_status=True) as resp:
             lines = decode_lines(iter_lines(resp, encoding="utf-8"))
             service_line = await anext(lines)
-            assert service_line == "# service=git-upload-pack"
+            if service_line != "# service=git-upload-pack":
+                raise UnexpectedResponse(f"invalid service line: {service_line!r}")
 
             # `async for` inside `dict()` not supported so no dict comprehension
             result = {}
@@ -62,6 +69,11 @@ async def fetch_pack(
             line_length = int(length_bytes, 16)
 
             line = await resp.content.readexactly(line_length - 4)
+
+            # e.g. "ERR upload-pack: not our ref <sha>"
+            if line[:3] == b"ERR":
+                raise RemoteError(line.decode("utf-8").strip())
+
             if line[:3] == b"NAK" or line[:3] == b"ACK":
                 # this is a difference in API between sync and async
                 # has to be read within this context to be used in the caller
@@ -97,11 +109,14 @@ async def send_pack(
             raise_for_status=True,
         ) as resp:
             lines = decode_lines(iter_lines(resp, encoding="utf-8"))
-            assert await anext(lines) == "unpack ok"
+            unpack_status = await anext(lines)
+            if unpack_status != "unpack ok":
+                raise UnpackFailed(unpack_status)
 
             line2 = await anext(lines)
             # ng = not good, ref update rejected
             if line2 == f"ng {ref} {HOOK_DECLINED_MSG}":
                 raise RefUpdateRejected(HOOK_DECLINED_MSG)
 
-            assert line2 == f"ok {ref}"
+            if line2 != f"ok {ref}":
+                raise UnexpectedResponse(f"unexpected ref status line: {line2!r}")

--- a/src/repligit/asyncio/client.py
+++ b/src/repligit/asyncio/client.py
@@ -3,6 +3,7 @@ from typing import Iterable
 import aiohttp
 
 from repligit.asyncio.parse import decode_lines, iter_lines
+from repligit.exceptions import HOOK_DECLINED_MSG, RefUpdateRejected
 from repligit.parse import generate_fetch_pack_request, generate_send_pack_header
 
 
@@ -100,7 +101,7 @@ async def send_pack(
 
             line2 = await anext(lines)
             # ng = not good, ref update rejected
-            if line2 == f"ng {ref} pre-receive hook declined":
-                raise Exception("pre-receive hook declined")
+            if line2 == f"ng {ref} {HOOK_DECLINED_MSG}":
+                raise RefUpdateRejected(HOOK_DECLINED_MSG)
 
             assert line2 == f"ok {ref}"

--- a/src/repligit/client.py
+++ b/src/repligit/client.py
@@ -2,6 +2,7 @@ import urllib.request
 from http.client import HTTPResponse
 from typing import BinaryIO, Iterable
 
+from repligit.exceptions import HOOK_DECLINED_MSG, RefUpdateRejected
 from repligit.parse import (
     decode_lines,
     generate_fetch_pack_request,
@@ -128,7 +129,7 @@ def send_pack(
 
     line2 = next(lines)
     # ng = not good, ref update rejected
-    if line2 == f"ng {ref} pre-receive hook declined":
-        raise Exception("pre-receive hook declined")
+    if line2 == f"ng {ref} {HOOK_DECLINED_MSG}":
+        raise RefUpdateRejected(HOOK_DECLINED_MSG)
 
     assert line2 == f"ok {ref}"

--- a/src/repligit/client.py
+++ b/src/repligit/client.py
@@ -2,7 +2,13 @@ import urllib.request
 from http.client import HTTPResponse
 from typing import BinaryIO, Iterable
 
-from repligit.exceptions import HOOK_DECLINED_MSG, RefUpdateRejected
+from repligit.exceptions import (
+    HOOK_DECLINED_MSG,
+    RefUpdateRejected,
+    RemoteError,
+    UnexpectedResponse,
+    UnpackFailed,
+)
 from repligit.parse import (
     decode_lines,
     generate_fetch_pack_request,
@@ -61,7 +67,8 @@ def ls_remote(
 
     lines = decode_lines(iter_lines(resp))
     service_line = next(lines)
-    assert service_line == "# service=git-upload-pack"
+    if service_line != "# service=git-upload-pack":
+        raise UnexpectedResponse(f"invalid service line: {service_line!r}")
 
     return {ref: sha for sha, ref in (line.split() for line in lines if line)}
 
@@ -92,6 +99,10 @@ def fetch_pack(
 
     line_length = int(resp.read(4), 16)
     line = resp.read(line_length - 4)
+
+    # e.g. "ERR upload-pack: not our ref <sha>"
+    if line[:3] == b"ERR":
+        raise RemoteError(line.decode("utf-8").strip())
 
     if line[:3] == b"NAK" or line[:3] == b"ACK":
         return resp
@@ -125,11 +136,14 @@ def send_pack(
     )
 
     lines = decode_lines(iter_lines(resp))
-    assert next(lines) == "unpack ok"
+    unpack_status = next(lines)
+    if unpack_status != "unpack ok":
+        raise UnpackFailed(unpack_status)
 
     line2 = next(lines)
     # ng = not good, ref update rejected
     if line2 == f"ng {ref} {HOOK_DECLINED_MSG}":
         raise RefUpdateRejected(HOOK_DECLINED_MSG)
 
-    assert line2 == f"ok {ref}"
+    if line2 != f"ok {ref}":
+        raise UnexpectedResponse(f"unexpected ref status line: {line2!r}")

--- a/src/repligit/exceptions.py
+++ b/src/repligit/exceptions.py
@@ -1,5 +1,21 @@
 HOOK_DECLINED_MSG = "pre-receive hook declined"
 
 
-class RefUpdateRejected(Exception):
+class RepligitError(Exception):
+    """Base class for all repligit errors."""
+
+
+class RefUpdateRejected(RepligitError):
     """Raised when the remote rejects a ref update during send-pack."""
+
+
+class RemoteError(RepligitError):
+    """Raised when the remote sends an ERR packet (e.g. want SHA not found)."""
+
+
+class UnpackFailed(RepligitError):
+    """Raised when the remote fails to unpack the packfile during send-pack."""
+
+
+class UnexpectedResponse(RepligitError):
+    """Raised when the remote sends a response repligit does not recognize."""

--- a/src/repligit/exceptions.py
+++ b/src/repligit/exceptions.py
@@ -1,0 +1,5 @@
+HOOK_DECLINED_MSG = "pre-receive hook declined"
+
+
+class RefUpdateRejected(Exception):
+    """Raised when the remote rejects a ref update during send-pack."""


### PR DESCRIPTION
Handles common issues with some custom exception classes:

- pre-receive hook failure
- invalid service line
- unexpected responses
- failure to unpack

follow up to https://github.com/llnl/repligit/pull/190

Makes it easier for customers to catch the exception rather than parse a generic error.