### PR TITLE
Correctly strip multi-line ACK status lines

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -16,10 +16,14 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pip'
-          cache-dependency-path: '.github/workflows/requirements/style.txt'
+          cache-dependency-path: |
+            pyproject.toml
+            .github/workflows/requirements/unit-tests.txt
+            .github/workflows/requirements/style.txt
 
       - name: Install Python dependencies
         run: |
+          pip install -r .github/workflows/requirements/unit-tests.txt
           pip install -r .github/workflows/requirements/style.txt
           pip install -e .[aiohttp]
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install .
           pip install -r .github/workflows/requirements/unit-tests.txt
+          pip install -e .[aiohttp]
 
       - name: Run Unit Tests (coverage on 3.13)
         run: |

--- a/README.md
+++ b/README.md
@@ -31,18 +31,14 @@ def main():
     # Note: Only provide credentials when authentication is required
     # src_username = "<username>"  # Uncomment if source repo requires auth
     # src_password = "<token>"     # Uncomment if source repo requires auth
-    dest_username = "<username>"   # For destination repo write access
-    dest_password = "<token>"      # For destination repo write access
+    dest_username = "<username>"  # For destination repo write access
+    dest_password = "<token>"  # For destination repo write access
 
     # List references from source repository (without authentication)
     gh_refs = ls_remote(src_remote_url)
 
     # List references from destination repository (with authentication)
-    gl_refs = ls_remote(
-        dest_remote_url,
-        username=dest_username,
-        password=dest_password
-    )
+    gl_refs = ls_remote(dest_remote_url, username=dest_username, password=dest_password)
 
     want_sha = gh_refs[target_ref]
     have_shas = set(gl_refs.values())
@@ -76,7 +72,6 @@ def main():
 
 if __name__ == "__main__":
     main()
-
 ```
 
 ## License

--- a/src/repligit/__init__.py
+++ b/src/repligit/__init__.py
@@ -1,3 +1,3 @@
 from repligit.client import fetch_pack, ls_remote, send_pack
 
-__all__ = ["ls_remote", "fetch_pack", "send_pack"]
+__all__ = ["fetch_pack", "ls_remote", "send_pack"]

--- a/src/repligit/asyncio/__init__.py
+++ b/src/repligit/asyncio/__init__.py
@@ -5,4 +5,4 @@ except ModuleNotFoundError:
 
 from repligit.asyncio.client import fetch_pack, ls_remote, send_pack
 
-__all__ = ["ls_remote", "fetch_pack", "send_pack"]
+__all__ = ["fetch_pack", "ls_remote", "send_pack"]

--- a/src/repligit/asyncio/client.py
+++ b/src/repligit/asyncio/client.py
@@ -1,11 +1,10 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 import aiohttp
 
-from repligit.asyncio.parse import decode_lines, iter_lines
+from repligit.asyncio.parse import decode_lines, iter_lines, read_packfile
 from repligit.exceptions import (
     RefUpdateRejected,
-    RemoteError,
     UnexpectedResponse,
     UnpackFailed,
 )
@@ -21,21 +20,23 @@ async def ls_remote(
 
     url = f"{url}/info/refs?service=git-upload-pack"
     auth = aiohttp.BasicAuth(username or "", password) if password else None
-    async with aiohttp.ClientSession(auth=auth) as session:
-        async with session.get(url, raise_for_status=True) as resp:
-            lines = decode_lines(iter_lines(resp, encoding="utf-8"))
-            service_line = await anext(lines)
-            if service_line != "# service=git-upload-pack":
-                raise UnexpectedResponse(f"invalid service line: {service_line!r}")
+    async with (
+        aiohttp.ClientSession(auth=auth) as session,
+        session.get(url, raise_for_status=True) as resp,
+    ):
+        lines = decode_lines(iter_lines(resp, encoding="utf-8"))
+        service_line = await anext(lines)
+        if service_line != "# service=git-upload-pack":
+            raise UnexpectedResponse(f"invalid service line: {service_line!r}")
 
-            # `async for` inside `dict()` not supported so no dict comprehension
-            result = {}
-            async for line in lines:
-                if not line:
-                    continue
-                sha, ref = line.split()
-                result[ref] = sha
-            return result
+        # `async for` inside `dict()` not supported so no dict comprehension
+        result = {}
+        async for line in lines:
+            if not line:
+                continue
+            sha, ref = line.split()
+            result[ref] = sha
+        return result
 
 
 async def fetch_pack(
@@ -54,8 +55,9 @@ async def fetch_pack(
 
     request = generate_fetch_pack_request(want_sha, have_shas)
 
-    async with aiohttp.ClientSession(auth=auth) as session:
-        async with session.post(
+    async with (
+        aiohttp.ClientSession(auth=auth) as session,
+        session.post(
             url,
             headers={
                 "Content-type": "application/x-git-upload-pack-request",
@@ -63,22 +65,11 @@ async def fetch_pack(
             data=request,
             raise_for_status=True,
             timeout=None,
-        ) as resp:
-            length_bytes = await resp.content.readexactly(4)
-            line_length = int(length_bytes, 16)
-
-            line = await resp.content.readexactly(line_length - 4)
-
-            # e.g. "ERR upload-pack: not our ref <sha>"
-            if line[:3] == b"ERR":
-                raise RemoteError(line.decode("utf-8").strip())
-
-            if line[:3] == b"NAK" or line[:3] == b"ACK":
-                # this is a difference in API between sync and async
-                # has to be read within this context to be used in the caller
-                return await resp.content.read()
-            else:
-                return None
+        ) as resp,
+    ):
+        # The packfile must be fully read within this async context so the
+        # caller can use it; read_packfile does so before returning.
+        return await read_packfile(resp.content)
 
 
 async def send_pack(
@@ -98,27 +89,29 @@ async def send_pack(
     # unlike in the sync version the packfile is already read into memory
     receive_pack_request = header + packfile
 
-    async with aiohttp.ClientSession(auth=auth) as session:
-        async with session.post(
+    async with (
+        aiohttp.ClientSession(auth=auth) as session,
+        session.post(
             url,
             headers={
                 "Content-type": "application/x-git-receive-pack-request",
             },
             data=receive_pack_request,
             raise_for_status=True,
-        ) as resp:
-            lines = decode_lines(iter_lines(resp, encoding="utf-8"))
-            unpack_status = await anext(lines)
-            if unpack_status != "unpack ok":
-                raise UnpackFailed(unpack_status)
+        ) as resp,
+    ):
+        lines = decode_lines(iter_lines(resp, encoding="utf-8"))
+        unpack_status = await anext(lines)
+        if unpack_status != "unpack ok":
+            raise UnpackFailed(unpack_status)
 
-            # "ng <ref> <reason>" (ng = not good) means the remote rejected the
-            # update. The reason may be non-fast-forward, hook declined, etc.
-            ref_status = await anext(lines)
-            prefix = f"ng {ref} "
-            if ref_status.startswith(prefix):
-                reason_str = ref_status[len(prefix) :]
-                raise RefUpdateRejected(reason_str)
+        # "ng <ref> <reason>" (ng = not good) means the remote rejected the
+        # update. The reason may be non-fast-forward, hook declined, etc.
+        ref_status = await anext(lines)
+        prefix = f"ng {ref} "
+        if ref_status.startswith(prefix):
+            reason_str = ref_status[len(prefix) :]
+            raise RefUpdateRejected(reason_str)
 
-            if ref_status != f"ok {ref}":
-                raise UnexpectedResponse(f"unexpected ref status line: {ref_status!r}")
+        if ref_status != f"ok {ref}":
+            raise UnexpectedResponse(f"unexpected ref status line: {ref_status!r}")

--- a/src/repligit/asyncio/parse.py
+++ b/src/repligit/asyncio/parse.py
@@ -1,6 +1,78 @@
-from typing import AsyncIterable, AsyncIterator
+import asyncio
+from collections.abc import AsyncIterable, AsyncIterator
 
 import aiohttp
+
+from repligit.exceptions import RemoteError, UnexpectedResponse
+
+
+async def read_packfile(reader: aiohttp.StreamReader) -> bytes | None:
+    """Drain a git-upload-pack negotiation section and return the packfile.
+
+    ``reader`` is an asynchronous byte stream exposing ``readexactly`` and
+    ``read`` (e.g. ``aiohttp.ClientResponse.content``).
+
+    The server response begins with a negotiation section made up of pkt-lines
+    (``NAK``, ``ACK <sha>``, ``ACK <sha> <status>``, ``shallow <sha>``, ...).
+    The packfile that follows is *not* a pkt-line: it starts with the literal
+    4-byte ``PACK`` signature. Servers may send several pkt-lines (e.g. multiple
+    ``ACK`` lines during negotiation), so we consume pkt-lines until the
+    ``PACK`` signature is reached.
+
+    Args:
+        reader: The asynchronous response byte stream.
+
+    Returns:
+        bytes: The packfile, including its ``PACK`` signature.
+        None: If the stream ends before a packfile is sent.
+
+    Raises:
+        RemoteError: If the server sends an ``ERR`` pkt-line.
+        UnexpectedResponse: If the stream is truncated mid-pkt-line or a
+            pkt-line is malformed.
+    """
+    while True:
+        try:
+            prefix = await reader.readexactly(4)
+        except asyncio.IncompleteReadError as e:
+            if not e.partial:
+                # Clean end of stream without a packfile (nothing to fetch).
+                return None
+            raise UnexpectedResponse(
+                f"response truncated mid-pkt-line: {e.partial!r}"
+            ) from None
+
+        # The packfile is not length-prefixed; it begins with "PACK". This can
+        # never collide with a pkt-line length prefix, which is 4 hex digits.
+        if prefix == b"PACK":
+            return prefix + await reader.read()
+
+        try:
+            line_length = int(prefix, 16)
+        except ValueError:
+            raise UnexpectedResponse(f"invalid pkt-line length: {prefix!r}") from None
+
+        if line_length == 0:
+            # Flush packet ("0000"); keep draining.
+            continue
+
+        if line_length < 4:
+            # 1-3 never denote a valid payload length in this response.
+            raise UnexpectedResponse(f"invalid pkt-line length: {prefix!r}")
+
+        try:
+            line = await reader.readexactly(line_length - 4)
+        except asyncio.IncompleteReadError as e:
+            raise UnexpectedResponse(
+                f"response truncated mid-pkt-line: expected {line_length - 4} "
+                f"bytes, got {len(e.partial)}"
+            ) from None
+
+        # e.g. "ERR upload-pack: not our ref <sha>"
+        if line[:3] == b"ERR":
+            raise RemoteError(line.decode("utf-8").strip())
+
+        # NAK / ACK / shallow / unshallow -> continue draining negotiation.
 
 
 async def decode_lines(line_stream: AsyncIterable) -> AsyncIterator:

--- a/src/repligit/client.py
+++ b/src/repligit/client.py
@@ -1,10 +1,10 @@
 import urllib.request
+from collections.abc import Iterable
 from http.client import HTTPResponse
-from typing import BinaryIO, Iterable
+from typing import BinaryIO
 
 from repligit.exceptions import (
     RefUpdateRejected,
-    RemoteError,
     UnexpectedResponse,
     UnpackFailed,
 )
@@ -13,6 +13,7 @@ from repligit.parse import (
     generate_fetch_pack_request,
     generate_send_pack_header,
     iter_lines,
+    read_packfile,
 )
 
 
@@ -78,7 +79,7 @@ def fetch_pack(
     have_shas: Iterable[str],
     username: str | None = None,
     password: str | None = None,
-) -> HTTPResponse | None:
+) -> BinaryIO | None:
     """Download a packfile from a remote server."""
     # ensure have_shas is a set, else packfile errors will occur
     have_shas = set(have_shas)
@@ -96,17 +97,15 @@ def fetch_pack(
         data=request,
     )
 
-    line_length = int(resp.read(4), 16)
-    line = resp.read(line_length - 4)
+    # Drain the negotiation section (NAK / ACK / shallow / ...) and return a
+    # stream over the packfile that follows, or None if the server sent no
+    # packfile. The packfile is streamed, not buffered into memory; closing
+    # the returned stream closes the HTTP response.
+    packfile = read_packfile(resp)
+    if packfile is None:
+        resp.close()
 
-    # e.g. "ERR upload-pack: not our ref <sha>"
-    if line[:3] == b"ERR":
-        raise RemoteError(line.decode("utf-8").strip())
-
-    if line[:3] == b"NAK" or line[:3] == b"ACK":
-        return resp
-    else:
-        return None
+    return packfile
 
 
 def send_pack(

--- a/src/repligit/parse.py
+++ b/src/repligit/parse.py
@@ -1,4 +1,8 @@
-from typing import IO, Generator, Iterable, Set
+import io
+from collections.abc import Generator, Iterable
+from typing import IO, BinaryIO
+
+from repligit.exceptions import RemoteError, UnexpectedResponse
 
 
 def iter_lines(
@@ -70,6 +74,126 @@ def encode_lines(lines: Iterable[bytes | str]) -> bytes:
     return b"".join(result)
 
 
+class _PackfileStream(io.RawIOBase):
+    """Read-only binary stream that replays the already-consumed ``PACK``
+    signature before delegating reads to the underlying response stream.
+
+    This lets ``read_packfile`` hand the packfile back to the caller as a
+    stream without buffering it in memory. Closing this stream closes the
+    underlying stream.
+    """
+
+    def __init__(self, stream: IO[bytes]):
+        self._stream = stream
+        self._prefix = b"PACK"
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, buffer) -> int:
+        # Serve the replayed signature first, then pass reads through.
+        if self._prefix:
+            n = min(len(buffer), len(self._prefix))
+            buffer[:n] = self._prefix[:n]
+            self._prefix = self._prefix[n:]
+            return n
+
+        chunk = self._stream.read(len(buffer))
+        buffer[: len(chunk)] = chunk
+        return len(chunk)
+
+    def close(self) -> None:
+        try:
+            self._stream.close()
+        finally:
+            super().close()
+
+
+def _read_exact(stream: IO[bytes], n: int) -> bytes:
+    """Read exactly ``n`` bytes from ``stream``, or fewer at end of stream.
+
+    Loops over ``stream.read``, so it tolerates file-like objects whose
+    ``read`` may return fewer bytes than requested before end of stream.
+    """
+    data = bytearray()
+    while len(data) < n:
+        chunk = stream.read(n - len(data))
+        if not chunk:
+            break
+        data += chunk
+    return bytes(data)
+
+
+def read_packfile(stream: IO[bytes]) -> BinaryIO | None:
+    """Drain a git-upload-pack negotiation section and return the packfile.
+
+    ``stream`` is a synchronous, file-like byte stream (e.g.
+    ``http.client.HTTPResponse``).
+
+    The server response begins with a negotiation section made up of pkt-lines
+    (``NAK``, ``ACK <sha>``, ``ACK <sha> <status>``, ``shallow <sha>``, ...).
+    The packfile that follows is *not* a pkt-line: it starts with the literal
+    4-byte ``PACK`` signature. Servers may send several pkt-lines (e.g. multiple
+    ``ACK`` lines during negotiation), so we consume pkt-lines until the
+    ``PACK`` signature is reached.
+
+    Args:
+        stream: The response byte stream.
+
+    Returns:
+        BinaryIO: A read-only stream over the packfile, starting at its
+            ``PACK`` signature. The packfile is *not* buffered in memory;
+            reads are forwarded to ``stream``, and closing the returned
+            stream closes ``stream``.
+        None: If the stream ends before a packfile is sent.
+
+    Raises:
+        RemoteError: If the server sends an ``ERR`` pkt-line.
+        UnexpectedResponse: If the stream is truncated mid-pkt-line or a
+            pkt-line is malformed.
+    """
+    while True:
+        prefix = _read_exact(stream, 4)
+
+        # The packfile is not length-prefixed; it begins with "PACK". This can
+        # never collide with a pkt-line length prefix, which is 4 hex digits.
+        if prefix == b"PACK":
+            return io.BufferedReader(_PackfileStream(stream))
+
+        if not prefix:
+            # Clean end of stream without a packfile (nothing to fetch).
+            return None
+
+        if len(prefix) < 4:
+            raise UnexpectedResponse(f"response truncated mid-pkt-line: {prefix!r}")
+
+        try:
+            line_length = int(prefix, 16)
+        except ValueError:
+            raise UnexpectedResponse(f"invalid pkt-line length: {prefix!r}") from None
+
+        if line_length == 0:
+            # Flush packet ("0000"); keep draining.
+            continue
+
+        if line_length < 4:
+            # 1-3 never denote a valid payload length in this response.
+            raise UnexpectedResponse(f"invalid pkt-line length: {prefix!r}")
+
+        line = _read_exact(stream, line_length - 4)
+        if len(line) < line_length - 4:
+            raise UnexpectedResponse(
+                f"response truncated mid-pkt-line: expected {line_length - 4} "
+                f"bytes, got {len(line)}"
+            )
+
+        # e.g. "ERR upload-pack: not our ref <sha>"
+        if line[:3] == b"ERR":
+            raise RemoteError(line.decode("utf-8").strip())
+
+        # NAK / ACK / shallow / unshallow -> continue draining negotiation.
+
+
 def generate_send_pack_header(ref: str, from_sha: str, to_sha: str) -> bytes:
     """
     Generate a Git send-pack header for updating references.
@@ -86,7 +210,7 @@ def generate_send_pack_header(ref: str, from_sha: str, to_sha: str) -> bytes:
     return encode_lines([f"{from_sha} {to_sha} {ref}\x00 report-status"]) + b"0000"
 
 
-def generate_fetch_pack_request(want: str, haves: Set[str]) -> bytes:
+def generate_fetch_pack_request(want: str, haves: set[str]) -> bytes:
     """Generate a git-upload packfile request.
 
     Args:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,155 @@
-from repligit.parse import decode_lines, encode_lines, generate_send_pack_header
+import asyncio
+import io
+from typing import cast
+
+import aiohttp
+import pytest
+
+from repligit.asyncio.parse import read_packfile as async_read_packfile
+from repligit.exceptions import RemoteError, UnexpectedResponse
+from repligit.parse import (
+    decode_lines,
+    encode_lines,
+    generate_send_pack_header,
+    read_packfile,
+)
+
+
+def _pkt(payload: bytes) -> bytes:
+    """Encode a single git pkt-line."""
+    return f"{len(payload) + 5:04x}".encode() + payload + b"\n"
+
+
+# A minimal but valid packfile body: "PACK", version 2, zero objects, trailer.
+FAKE_PACK = b"PACK\x00\x00\x00\x02\x00\x00\x00\x00" + b"\x00" * 20
+
+SHA_A = "a" * 40
+SHA_B = "b" * 40
+
+
+class _AsyncStream:
+    """Minimal async byte reader mimicking aiohttp's StreamReader."""
+
+    def __init__(self, data: bytes):
+        self._buf = data
+
+    async def readexactly(self, n: int) -> bytes:
+        if len(self._buf) < n:
+            partial, self._buf = self._buf, b""
+            raise asyncio.IncompleteReadError(partial, n)
+        chunk, self._buf = self._buf[:n], self._buf[n:]
+        return chunk
+
+    async def read(self, n: int = -1) -> bytes:
+        if n < 0:
+            chunk, self._buf = self._buf, b""
+            return chunk
+        chunk, self._buf = self._buf[:n], self._buf[n:]
+        return chunk
+
+
+def _run_async(data: bytes) -> bytes | None:
+    reader = cast(aiohttp.StreamReader, _AsyncStream(data))
+    return asyncio.run(async_read_packfile(reader))
+
+
+# Responses exercised by both the sync and async read_packfile helpers.
+_PACKFILE_CASES = [
+    # Single NAK line immediately followed by the pack.
+    pytest.param(_pkt(b"NAK") + FAKE_PACK, FAKE_PACK, id="nak"),
+    # Single terminal ACK line followed by the pack.
+    pytest.param(_pkt(f"ACK {SHA_A}".encode()) + FAKE_PACK, FAKE_PACK, id="single_ack"),
+    # Regression: multiple ACK lines precede the pack (multi-ack negotiation as
+    # emitted by GitHub/GitLab). Previously only the first line was consumed,
+    # leaving "ACK ..." bytes in front of the pack and corrupting its signature.
+    pytest.param(
+        _pkt(f"ACK {SHA_A} common".encode())
+        + _pkt(f"ACK {SHA_B} common".encode())
+        + _pkt(f"ACK {SHA_B}".encode())
+        + FAKE_PACK,
+        FAKE_PACK,
+        id="multi_ack",
+    ),
+    # Shallow lines and a flush packet precede the pack.
+    pytest.param(
+        _pkt(f"shallow {SHA_A}".encode()) + b"0000" + _pkt(b"NAK") + FAKE_PACK,
+        FAKE_PACK,
+        id="shallow_and_flush",
+    ),
+    # Negotiation only, no packfile (stream ends): returns None.
+    pytest.param(_pkt(b"NAK"), None, id="no_pack"),
+]
+
+_ERR_RESPONSE = _pkt(b"ERR upload-pack: not our ref " + SHA_A.encode())
+
+# Malformed or truncated responses that must raise UnexpectedResponse rather
+# than being silently misread as "no packfile".
+_BAD_RESPONSES = [
+    # Connection dropped mid-length-prefix.
+    pytest.param(_pkt(b"NAK") + b"00", id="truncated_prefix"),
+    # Connection dropped mid-pkt-line payload.
+    pytest.param(_pkt(f"ACK {SHA_A}".encode())[:20], id="truncated_line"),
+    # Length prefix is not hex (and not "PACK").
+    pytest.param(b"zzzz" + FAKE_PACK, id="garbage_prefix"),
+    # Lengths 1-3 can never denote a valid pkt-line in this response.
+    pytest.param(b"0002" + _pkt(b"NAK") + FAKE_PACK, id="bogus_length"),
+]
+
+
+@pytest.mark.parametrize("raw,expected", _PACKFILE_CASES)
+def test_read_packfile_sync(raw, expected):
+    stream = read_packfile(io.BytesIO(raw))
+    if expected is None:
+        assert stream is None
+    else:
+        assert stream is not None
+        assert stream.read() == expected
+
+
+def test_read_packfile_sync_streams_incrementally():
+    """The consumed PACK signature is replayed and reads pass through."""
+    stream = read_packfile(io.BytesIO(_pkt(b"NAK") + FAKE_PACK))
+    assert stream is not None
+    assert stream.read(2) == b"PA"
+    assert stream.read(6) == b"CK\x00\x00\x00\x02"
+    assert stream.read() == FAKE_PACK[8:]
+    assert stream.read() == b""
+
+
+def test_read_packfile_sync_close_propagates():
+    """Closing the packfile stream closes the underlying response stream."""
+    underlying = io.BytesIO(_pkt(b"NAK") + FAKE_PACK)
+    stream = read_packfile(underlying)
+    assert stream is not None
+    stream.close()
+    assert underlying.closed
+
+
+@pytest.mark.parametrize("raw,expected", _PACKFILE_CASES)
+def test_read_packfile_async(raw, expected):
+    assert _run_async(raw) == expected
+
+
+def test_read_packfile_sync_raises_on_err():
+    with pytest.raises(RemoteError):
+        read_packfile(io.BytesIO(_ERR_RESPONSE))
+
+
+def test_read_packfile_async_raises_on_err():
+    with pytest.raises(RemoteError):
+        _run_async(_ERR_RESPONSE)
+
+
+@pytest.mark.parametrize("raw", _BAD_RESPONSES)
+def test_read_packfile_sync_raises_on_malformed(raw):
+    with pytest.raises(UnexpectedResponse):
+        read_packfile(io.BytesIO(raw))
+
+
+@pytest.mark.parametrize("raw", _BAD_RESPONSES)
+def test_read_packfile_async_raises_on_malformed(raw):
+    with pytest.raises(UnexpectedResponse):
+        _run_async(raw)
 
 
 def test_decode_lines():


### PR DESCRIPTION
This PR fixes "pack signature mismatch" error in fetch_pack → send_pack when the server response contains multiple NACK / ACK status lines. Previously we assumed (incorrectly) that there would only ever be a single status line before the returned packfile. In some complex mirror situations where multiple commits are reused across two remotes multiple status lines can be returned with a packfile.