### PR TITLE
Frame git responses by pkt-line length instead of newlines

### DIFF
--- a/src/repligit/asyncio/client.py
+++ b/src/repligit/asyncio/client.py
@@ -2,7 +2,7 @@ from typing import Iterable
 
 import aiohttp
 
-from repligit.asyncio.parse import decode_lines, iter_lines
+from repligit.asyncio.parse import read_pkt_lines
 from repligit.exceptions import (
     RefUpdateRejected,
     RemoteError,
@@ -23,19 +23,17 @@ async def ls_remote(
     auth = aiohttp.BasicAuth(username or "", password) if password else None
     async with aiohttp.ClientSession(auth=auth) as session:
         async with session.get(url, raise_for_status=True) as resp:
-            lines = decode_lines(iter_lines(resp, encoding="utf-8"))
+            lines = read_pkt_lines(resp.content)
             service_line = await anext(lines)
             if service_line != "# service=git-upload-pack":
                 raise UnexpectedResponse(f"invalid service line: {service_line!r}")
 
-            # `async for` inside `dict()` not supported so no dict comprehension
-            result = {}
+            refs: dict[str, str] = {}
             async for line in lines:
-                if not line:
-                    continue
-                sha, ref = line.split()
-                result[ref] = sha
-            return result
+                # The first ref line carries the server capabilities after a NUL byte.
+                sha, ref = line.split("\x00", 1)[0].split()
+                refs[ref] = sha
+            return refs
 
 
 async def fetch_pack(
@@ -107,7 +105,7 @@ async def send_pack(
             data=receive_pack_request,
             raise_for_status=True,
         ) as resp:
-            lines = decode_lines(iter_lines(resp, encoding="utf-8"))
+            lines = read_pkt_lines(resp.content)
             unpack_status = await anext(lines)
             if unpack_status != "unpack ok":
                 raise UnpackFailed(unpack_status)

--- a/src/repligit/asyncio/parse.py
+++ b/src/repligit/asyncio/parse.py
@@ -1,51 +1,92 @@
-from typing import AsyncIterable, AsyncIterator
+import asyncio
+from typing import AsyncIterator
 
 import aiohttp
 
+from repligit.exceptions import RemoteError, UnexpectedResponse
+from repligit.parse import parse_pkt_length
 
-async def decode_lines(line_stream: AsyncIterable) -> AsyncIterator:
-    """Decode git server response iterator into individual data lines.
 
-    This asynchronous function processes a stream of lines from a server response,
-    where each line is prefixed with a 4-character hexadecimal length indicator.
-    It extracts and yields the actual data portion of each line.
+async def _read_pkt_prefix(reader: aiohttp.StreamReader) -> bytes:
+    """Read the next 4-byte pkt-line length prefix.
 
-    Args:
-        line_stream: An asynchronous iterable providing the raw server response lines.
-
-    Yields:
-        The decoded data portion of each line, with the length prefix removed.
+    Returns ``b""`` at a clean end of stream. Raises ``UnexpectedResponse``
+    if the stream is truncated mid-prefix.
     """
-    async for line in line_stream:
-        line_length = int(line[:4], 16)
-        yield line[4:line_length]
+    try:
+        return await reader.readexactly(4)
+    except asyncio.IncompleteReadError as e:
+        if not e.partial:
+            return b""
+        raise UnexpectedResponse(
+            f"response truncated mid-pkt-line: {e.partial!r}"
+        ) from None
 
 
-async def iter_lines(
-    resp: aiohttp.ClientResponse, encoding: str = "utf-8", chunk_size: int = 16 * 1024
+async def _read_pkt_payload(
+    reader: aiohttp.StreamReader, line_length: int, encoding: str = "utf-8"
+) -> bytes:
+    """Read the payload of a pkt-line whose length prefix was already read.
+
+    Raises ``UnexpectedResponse`` if the stream is truncated mid-payload and
+    ``RemoteError`` if the payload is an ``ERR`` line (e.g. "ERR upload-pack:
+    not our ref <sha>").
+    """
+    payload_length = line_length - 4
+    try:
+        payload = await reader.readexactly(payload_length)
+    except asyncio.IncompleteReadError as e:
+        raise UnexpectedResponse(
+            f"response truncated mid-pkt-line: expected {payload_length} "
+            f"bytes, got {len(e.partial)}"
+        ) from None
+
+    if payload[:3] == b"ERR":
+        raise RemoteError(payload.decode(encoding).strip())
+
+    return payload
+
+
+async def read_pkt_lines(
+    reader: aiohttp.StreamReader, encoding: str = "utf-8"
 ) -> AsyncIterator[str]:
-    """
-    Asynchronously iterate over the lines of an HTTP response.
+    """Yield the decoded payload of each pkt-line from a git response stream.
+
+    This frames the stream by length exactly as the git pkt-line format
+    dictates rather than splitting on newlines, which is fragile: pkt-line
+    payloads may embed ``\\0`` (capabilities) and flush packets (``0000``)
+    carry no trailing newline. Each pkt-line is read as a 4-hex-digit length
+    prefix followed by ``length - 4`` payload bytes.
+
+    Flush packets (``0000``) are skipped. A single optional trailing ``LF`` is
+    stripped from each payload before it is decoded and yielded.
+
+    ``reader`` is an asynchronous byte stream exposing ``readexactly``
+    (e.g. ``aiohttp.ClientResponse.content``).
 
     Args:
-        resp: The aiohttp ClientResponse object to read from.
-        encoding: The character encoding to use for decoding bytes to strings.
-            Defaults to "utf-8".
-        chunk_size: The number of bytes to read in each chunk.
-            Defaults to 16 KiB (16 * 1024 bytes).
+        reader: The asynchronous response byte stream.
+        encoding: Character encoding used to decode payloads. Defaults to
+            "utf-8".
 
     Yields:
-        str: Each line from the response, with trailing carriage returns removed
-            and decoded using the specified encoding.
+        str: The decoded payload of each data pkt-line.
+
+    Raises:
+        RemoteError: If the server sends an ``ERR`` pkt-line.
+        UnexpectedResponse: If the stream is truncated mid-pkt-line or a
+            pkt-line is malformed.
     """
-    incomplete_line = bytearray()
+    while True:
+        prefix = await _read_pkt_prefix(reader)
+        if not prefix:
+            # Clean end of stream.
+            return
 
-    async for chunk in resp.content.iter_chunked(chunk_size):
-        lines = (incomplete_line + chunk).split(b"\n")
-        incomplete_line = lines.pop()
+        line_length = parse_pkt_length(prefix)
+        if line_length == 0:
+            # Flush packet ("0000"); carries no payload.
+            continue
 
-        for line in lines:
-            yield line.rstrip(b"\r").decode(encoding)
-
-    if incomplete_line:
-        yield incomplete_line.rstrip(b"\r").decode(encoding)
+        payload = await _read_pkt_payload(reader, line_length, encoding)
+        yield payload.removesuffix(b"\n").decode(encoding)

--- a/src/repligit/asyncio/parse.py
+++ b/src/repligit/asyncio/parse.py
@@ -77,12 +77,8 @@ async def read_pkt_lines(
         UnexpectedResponse: If the stream is truncated mid-pkt-line or a
             pkt-line is malformed.
     """
-    while True:
-        prefix = await _read_pkt_prefix(reader)
-        if not prefix:
-            # Clean end of stream.
-            return
-
+    # An empty prefix means a clean end of stream.
+    while prefix := await _read_pkt_prefix(reader):
         line_length = parse_pkt_length(prefix)
         if line_length == 0:
             # Flush packet ("0000"); carries no payload.

--- a/src/repligit/client.py
+++ b/src/repligit/client.py
@@ -9,10 +9,9 @@ from repligit.exceptions import (
     UnpackFailed,
 )
 from repligit.parse import (
-    decode_lines,
     generate_fetch_pack_request,
     generate_send_pack_header,
-    iter_lines,
+    read_pkt_lines,
 )
 
 
@@ -64,12 +63,17 @@ def ls_remote(
 
     resp = http_request(url, username=username, password=password)
 
-    lines = decode_lines(iter_lines(resp))
+    lines = read_pkt_lines(resp)
     service_line = next(lines)
     if service_line != "# service=git-upload-pack":
         raise UnexpectedResponse(f"invalid service line: {service_line!r}")
 
-    return {ref: sha for sha, ref in (line.split() for line in lines if line)}
+    refs: dict[str, str] = {}
+    for line in lines:
+        # The first ref line carries the server capabilities after a NUL byte.
+        sha, ref = line.split("\x00", 1)[0].split()
+        refs[ref] = sha
+    return refs
 
 
 def fetch_pack(
@@ -134,7 +138,7 @@ def send_pack(
         data=receive_pack_request,
     )
 
-    lines = decode_lines(iter_lines(resp))
+    lines = read_pkt_lines(resp)
     unpack_status = next(lines)
     if unpack_status != "unpack ok":
         raise UnpackFailed(unpack_status)

--- a/src/repligit/parse.py
+++ b/src/repligit/parse.py
@@ -1,52 +1,126 @@
 from typing import IO, Generator, Iterable, Set
 
+from repligit.exceptions import RemoteError, UnexpectedResponse
 
-def iter_lines(
-    data: IO, encoding: str = "utf-8", chunk_size: int = 16 * 1024
+
+def parse_pkt_length(prefix: bytes) -> int:
+    """Parse and validate a 4-byte pkt-line length prefix.
+
+    Args:
+        prefix: The 4-byte hexadecimal length prefix of a pkt-line.
+
+    Returns:
+        int: The total pkt-line length. ``0`` denotes a flush packet.
+
+    Raises:
+        UnexpectedResponse: If the prefix is not hexadecimal or denotes an
+            impossible length (1-3 can never fit the 4-byte prefix itself).
+    """
+    try:
+        line_length = int(prefix, 16)
+    except ValueError:
+        raise UnexpectedResponse(f"invalid pkt-line length: {prefix!r}") from None
+
+    if 0 < line_length < 4:
+        raise UnexpectedResponse(f"invalid pkt-line length: {prefix!r}")
+
+    return line_length
+
+
+def _read_exact(stream: IO[bytes], n: int) -> bytes:
+    """Read exactly ``n`` bytes from ``stream``, or fewer at end of stream.
+
+    Loops over ``stream.read``, so it tolerates file-like objects whose
+    ``read`` may return fewer bytes than requested before end of stream.
+    """
+    data = bytearray()
+    while len(data) < n:
+        chunk = stream.read(n - len(data))
+        if not chunk:
+            break
+        data += chunk
+    return bytes(data)
+
+
+def _read_pkt_prefix(stream: IO[bytes]) -> bytes:
+    """Read the next 4-byte pkt-line length prefix.
+
+    Returns ``b""`` at a clean end of stream. Raises ``UnexpectedResponse``
+    if the stream is truncated mid-prefix.
+    """
+    prefix = _read_exact(stream, 4)
+    if prefix and len(prefix) < 4:
+        raise UnexpectedResponse(f"response truncated mid-pkt-line: {prefix!r}")
+    return prefix
+
+
+def _read_pkt_payload(
+    stream: IO[bytes], line_length: int, encoding: str = "utf-8"
+) -> bytes:
+    """Read the payload of a pkt-line whose length prefix was already read.
+
+    Raises ``UnexpectedResponse`` if the stream is truncated mid-payload and
+    ``RemoteError`` if the payload is an ``ERR`` line (e.g. "ERR upload-pack:
+    not our ref <sha>").
+    """
+    payload_length = line_length - 4
+    payload = _read_exact(stream, payload_length)
+    if len(payload) < payload_length:
+        raise UnexpectedResponse(
+            f"response truncated mid-pkt-line: expected {payload_length} "
+            f"bytes, got {len(payload)}"
+        )
+
+    if payload[:3] == b"ERR":
+        raise RemoteError(payload.decode(encoding).strip())
+
+    return payload
+
+
+def read_pkt_lines(
+    stream: IO[bytes], encoding: str = "utf-8"
 ) -> Generator[str, None, None]:
-    """
-    Iterate over the lines of a file-like object, yielding one line at a time.
+    """Yield the decoded payload of each pkt-line from a git response stream.
+
+    This frames the stream by length exactly as the git pkt-line format
+    dictates rather than splitting on newlines, which is fragile: pkt-line
+    payloads may embed ``\\0`` (capabilities) and flush packets (``0000``)
+    carry no trailing newline. Each pkt-line is read as a 4-hex-digit length
+    prefix followed by ``length - 4`` payload bytes.
+
+    Flush packets (``0000``) are skipped. A single optional trailing ``LF`` is
+    stripped from each payload before it is decoded and yielded.
+
+    ``stream`` is a synchronous, file-like byte stream (e.g.
+    ``http.client.HTTPResponse``). Short reads before end of stream are
+    tolerated.
 
     Args:
-        data: A file-like object with a read() method that returns bytes
-        encoding (str, optional): Character encoding to use for decoding bytes to strings.
+        stream: The response byte stream.
+        encoding (str, optional): Character encoding used to decode payloads.
             Defaults to "utf-8".
-        chunk_size (int, optional): Number of bytes to read in each chunk.
-            Defaults to 16 KiB.
 
     Yields:
-        str: Each line from the input data, with line endings removed.
+        str: The decoded payload of each data pkt-line.
+
+    Raises:
+        RemoteError: If the server sends an ``ERR`` pkt-line.
+        UnexpectedResponse: If the stream is truncated mid-pkt-line or a
+            pkt-line is malformed.
     """
-    incomplete_line = bytearray()
+    while True:
+        prefix = _read_pkt_prefix(stream)
+        if not prefix:
+            # Clean end of stream.
+            return
 
-    for chunk in iter(lambda: data.read(chunk_size), b""):
-        lines = (incomplete_line + chunk).split(b"\n")
-        incomplete_line = lines.pop()
+        line_length = parse_pkt_length(prefix)
+        if line_length == 0:
+            # Flush packet ("0000"); carries no payload.
+            continue
 
-        for line in lines:
-            yield line.rstrip(b"\r").decode(encoding)
-
-    if incomplete_line:
-        yield incomplete_line.rstrip(b"\r").decode(encoding)
-
-
-def decode_lines(lines: Iterable[str]) -> Generator[str, None, None]:
-    """
-    Decode lines from the git transfer protocol into usable lines.
-
-    This asynchronous function processes a stream of lines from a server response,
-    where each line is prefixed with a 4-character hexadecimal length indicator.
-    It extracts and yields the actual data portion of each line.
-
-    Args:
-        lines: A generator yielding strings from a git server response.
-
-    Yields:
-        str: Decoded content from each line with the length prefix removed.
-    """
-    for line in lines:
-        line_length = int(line[:4], 16)
-        yield line[4:line_length]
+        payload = _read_pkt_payload(stream, line_length, encoding)
+        yield payload.removesuffix(b"\n").decode(encoding)
 
 
 def encode_lines(lines: Iterable[bytes | str]) -> bytes:

--- a/src/repligit/parse.py
+++ b/src/repligit/parse.py
@@ -108,12 +108,8 @@ def read_pkt_lines(
         UnexpectedResponse: If the stream is truncated mid-pkt-line or a
             pkt-line is malformed.
     """
-    while True:
-        prefix = _read_pkt_prefix(stream)
-        if not prefix:
-            # Clean end of stream.
-            return
-
+    # An empty prefix means a clean end of stream.
+    while prefix := _read_pkt_prefix(stream):
         line_length = parse_pkt_length(prefix)
         if line_length == 0:
             # Flush packet ("0000"); carries no payload.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -37,13 +37,11 @@ class _AsyncStream:
         return chunk
 
 
-def _async_stream(data: bytes) -> aiohttp.StreamReader:
-    return cast(aiohttp.StreamReader, _AsyncStream(data))
-
-
 def _collect_async_pkt_lines(raw: bytes) -> list[str]:
+    stream = cast(aiohttp.StreamReader, _AsyncStream(raw))
+
     async def _collect() -> list[str]:
-        return [line async for line in async_read_pkt_lines(_async_stream(raw))]
+        return [line async for line in async_read_pkt_lines(stream)]
 
     return asyncio.run(_collect())
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,21 +1,124 @@
-from repligit.parse import decode_lines, encode_lines, generate_send_pack_header
+import asyncio
+import io
+from typing import cast
+
+import aiohttp
+import pytest
+
+from repligit.asyncio.parse import read_pkt_lines as async_read_pkt_lines
+from repligit.exceptions import RemoteError, UnexpectedResponse
+from repligit.parse import (
+    encode_lines,
+    generate_send_pack_header,
+    read_pkt_lines,
+)
 
 
-def test_decode_lines():
-    raw_lines = [
-        "003fbef547a59eec448284136f03984dce0f2f8239a9 refs/pull/95/head",
-        "003f358aa046cd57dbca306e80d4c3fbb86edc5b36af refs/pull/96/head",
-        "0000",
-    ]
+def _pkt(payload: bytes) -> bytes:
+    """Encode a single git pkt-line."""
+    return f"{len(payload) + 5:04x}".encode() + payload + b"\n"
 
-    decoded_lines = [
-        "bef547a59eec448284136f03984dce0f2f8239a9 refs/pull/95/head",
-        "358aa046cd57dbca306e80d4c3fbb86edc5b36af refs/pull/96/head",
-        "",
-    ]
 
-    lines = list(decode_lines(raw_lines))
-    assert decoded_lines == lines
+SHA_A = "a" * 40
+SHA_B = "b" * 40
+
+
+class _AsyncStream:
+    """Minimal async byte reader mimicking aiohttp's StreamReader."""
+
+    def __init__(self, data: bytes):
+        self._buf = data
+
+    async def readexactly(self, n: int) -> bytes:
+        if len(self._buf) < n:
+            partial, self._buf = self._buf, b""
+            raise asyncio.IncompleteReadError(partial, n)
+        chunk, self._buf = self._buf[:n], self._buf[n:]
+        return chunk
+
+
+def _async_stream(data: bytes) -> aiohttp.StreamReader:
+    return cast(aiohttp.StreamReader, _AsyncStream(data))
+
+
+def _collect_async_pkt_lines(raw: bytes) -> list[str]:
+    async def _collect() -> list[str]:
+        return [line async for line in async_read_pkt_lines(_async_stream(raw))]
+
+    return asyncio.run(_collect())
+
+
+_ERR_RESPONSE = _pkt(b"ERR upload-pack: not our ref " + SHA_A.encode())
+
+
+# A realistic git-upload-pack ref advertisement. Note the flush packet after
+# the service line carries no trailing newline, and the first ref line embeds
+# the server capabilities after a NUL byte.
+_ADVERTISEMENT = (
+    _pkt(b"# service=git-upload-pack")
+    + b"0000"
+    + _pkt(
+        f"{SHA_A} HEAD\x00multi_ack thin-pack side-band-64k "
+        f"symref=HEAD:refs/heads/main".encode()
+    )
+    + _pkt(f"{SHA_A} refs/heads/main".encode())
+    + _pkt(f"{SHA_B} refs/tags/v1".encode())
+    + b"0000"
+)
+
+_ADVERTISEMENT_LINES = [
+    "# service=git-upload-pack",
+    f"{SHA_A} HEAD\x00multi_ack thin-pack side-band-64k symref=HEAD:refs/heads/main",
+    f"{SHA_A} refs/heads/main",
+    f"{SHA_B} refs/tags/v1",
+]
+
+
+def test_read_pkt_lines_frames_by_length_sync():
+    # Flush packets are skipped and one trailing LF is stripped per payload.
+    lines = list(read_pkt_lines(io.BytesIO(_ADVERTISEMENT)))
+    assert lines == _ADVERTISEMENT_LINES
+
+
+def test_read_pkt_lines_frames_by_length_async():
+    assert _collect_async_pkt_lines(_ADVERTISEMENT) == _ADVERTISEMENT_LINES
+
+
+# Malformed or truncated pkt-line streams that must raise UnexpectedResponse
+# rather than yielding truncated or garbage lines.
+_BAD_PKT_STREAMS = [
+    # Connection dropped mid-length-prefix.
+    pytest.param(_pkt(b"unpack ok") + b"00", id="truncated_prefix"),
+    # Connection dropped mid-pkt-line payload.
+    pytest.param(_pkt(b"unpack ok")[:8], id="truncated_payload"),
+    # Length prefix is not hex.
+    pytest.param(b"zzzz" + _pkt(b"unpack ok"), id="garbage_prefix"),
+    # Lengths 1-3 can never fit the 4-byte prefix itself. Notably, "0002"
+    # previously triggered read(-2), swallowing the rest of the stream.
+    pytest.param(b"0002" + _pkt(b"unpack ok"), id="bogus_length"),
+]
+
+
+@pytest.mark.parametrize("raw", _BAD_PKT_STREAMS)
+def test_read_pkt_lines_sync_raises_on_malformed(raw):
+    with pytest.raises(UnexpectedResponse):
+        list(read_pkt_lines(io.BytesIO(raw)))
+
+
+@pytest.mark.parametrize("raw", _BAD_PKT_STREAMS)
+def test_read_pkt_lines_async_raises_on_malformed(raw):
+    with pytest.raises(UnexpectedResponse):
+        _collect_async_pkt_lines(raw)
+
+
+def test_read_pkt_lines_sync_raises_on_err():
+    with pytest.raises(RemoteError):
+        list(read_pkt_lines(io.BytesIO(_ERR_RESPONSE)))
+
+
+def test_read_pkt_lines_async_raises_on_err():
+    with pytest.raises(RemoteError):
+        _collect_async_pkt_lines(_ERR_RESPONSE)
 
 
 def test_encode_lines_from_bytes():


### PR DESCRIPTION
Depends on #212 

Replace the newline-splitting iter_lines/decode_lines helpers with read_pkt_lines, which reads each pkt-line as a 4-hex-digit length prefix followed by exactly length - 4 payload bytes, as the git protocol dictates.

Splitting on newlines was fragile: payloads may embed NUL bytes (capabilities), flush packets carry no trailing newline, and the first ref line of an advertisement (HEAD) was silently dropped. The new framing also validates length prefixes, raises UnexpectedResponse on truncated or malformed streams, and surfaces server ERR pkt-lines as RemoteError in both the sync and async clients.