### PR TITLE
Correctly strip multi-line ACK status lines

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -16,10 +16,14 @@ jobs:
         with:
           python-version: '3.10'
           cache: 'pip'
-          cache-dependency-path: '.github/workflows/requirements/style.txt'
+          cache-dependency-path: |
+            pyproject.toml
+            .github/workflows/requirements/unit-tests.txt
+            .github/workflows/requirements/style.txt
 
       - name: Install Python dependencies
         run: |
+          pip install -r .github/workflows/requirements/unit-tests.txt
           pip install -r .github/workflows/requirements/style.txt
           pip install -e .[aiohttp]
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -23,8 +23,8 @@ jobs:
 
       - name: Install Python dependencies
         run: |
-          pip install .
           pip install -r .github/workflows/requirements/unit-tests.txt
+          pip install -e .[aiohttp]
 
       - name: Run Unit Tests (coverage on 3.13)
         run: |

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ def main():
     gl_refs = ls_remote(
         dest_remote_url,
         username=dest_username,
-        password=dest_password
+        password=dest_password,
     )
 
     want_sha = gh_refs[target_ref]
@@ -76,7 +76,6 @@ def main():
 
 if __name__ == "__main__":
     main()
-
 ```
 
 ## License

--- a/spack.yaml
+++ b/spack.yaml
@@ -8,7 +8,7 @@ spack:
   specs:
   - py-codespell
   - py-pytest
-  - py-repligit
+  - py-repligit +aiohttp
   - py-bandit
   - py-ruff
   - py-pip

--- a/src/repligit/__init__.py
+++ b/src/repligit/__init__.py
@@ -1,3 +1,3 @@
 from repligit.client import fetch_pack, ls_remote, send_pack
 
-__all__ = ["ls_remote", "fetch_pack", "send_pack"]
+__all__ = ["fetch_pack", "ls_remote", "send_pack"]

--- a/src/repligit/asyncio/__init__.py
+++ b/src/repligit/asyncio/__init__.py
@@ -5,4 +5,4 @@ except ModuleNotFoundError:
 
 from repligit.asyncio.client import fetch_pack, ls_remote, send_pack
 
-__all__ = ["ls_remote", "fetch_pack", "send_pack"]
+__all__ = ["fetch_pack", "ls_remote", "send_pack"]

--- a/src/repligit/asyncio/client.py
+++ b/src/repligit/asyncio/client.py
@@ -1,8 +1,8 @@
-from typing import Iterable
+from collections.abc import Iterable
 
 import aiohttp
 
-from repligit.asyncio.parse import decode_lines, iter_lines
+from repligit.asyncio.parse import read_pkt_lines
 from repligit.exceptions import (
     RefUpdateRejected,
     RemoteError,
@@ -21,21 +21,21 @@ async def ls_remote(
 
     url = f"{url}/info/refs?service=git-upload-pack"
     auth = aiohttp.BasicAuth(username or "", password) if password else None
-    async with aiohttp.ClientSession(auth=auth) as session:
-        async with session.get(url, raise_for_status=True) as resp:
-            lines = decode_lines(iter_lines(resp, encoding="utf-8"))
-            service_line = await anext(lines)
-            if service_line != "# service=git-upload-pack":
-                raise UnexpectedResponse(f"invalid service line: {service_line!r}")
+    async with (
+        aiohttp.ClientSession(auth=auth) as session,
+        session.get(url, raise_for_status=True) as resp,
+    ):
+        lines = read_pkt_lines(resp.content)
+        service_line = await anext(lines)
+        if service_line != "# service=git-upload-pack":
+            raise UnexpectedResponse(f"invalid service line: {service_line!r}")
 
-            # `async for` inside `dict()` not supported so no dict comprehension
-            result = {}
-            async for line in lines:
-                if not line:
-                    continue
-                sha, ref = line.split()
-                result[ref] = sha
-            return result
+        refs: dict[str, str] = {}
+        async for line in lines:
+            # The first ref line carries the server capabilities after a NUL byte.
+            sha, ref = line.split("\x00", 1)[0].split()
+            refs[ref] = sha
+        return refs
 
 
 async def fetch_pack(
@@ -54,8 +54,9 @@ async def fetch_pack(
 
     request = generate_fetch_pack_request(want_sha, have_shas)
 
-    async with aiohttp.ClientSession(auth=auth) as session:
-        async with session.post(
+    async with (
+        aiohttp.ClientSession(auth=auth) as session,
+        session.post(
             url,
             headers={
                 "Content-type": "application/x-git-upload-pack-request",
@@ -63,22 +64,22 @@ async def fetch_pack(
             data=request,
             raise_for_status=True,
             timeout=None,
-        ) as resp:
-            length_bytes = await resp.content.readexactly(4)
-            line_length = int(length_bytes, 16)
+        ) as resp,
+    ):
+        length_bytes = await resp.content.readexactly(4)
+        line_length = int(length_bytes, 16)
 
-            line = await resp.content.readexactly(line_length - 4)
+        line = await resp.content.readexactly(line_length - 4)
 
-            # e.g. "ERR upload-pack: not our ref <sha>"
-            if line[:3] == b"ERR":
-                raise RemoteError(line.decode("utf-8").strip())
+        # e.g. "ERR upload-pack: not our ref <sha>"
+        if line[:3] == b"ERR":
+            raise RemoteError(line.decode("utf-8").strip())
 
-            if line[:3] == b"NAK" or line[:3] == b"ACK":
-                # this is a difference in API between sync and async
-                # has to be read within this context to be used in the caller
-                return await resp.content.read()
-            else:
-                return None
+        if line[:3] in (b"NAK", b"ACK"):
+            # Unlike the sync version, the packfile must be read here, while
+            # the response is still open, and returned as bytes.
+            return await resp.content.read()
+        return None
 
 
 async def send_pack(
@@ -98,27 +99,29 @@ async def send_pack(
     # unlike in the sync version the packfile is already read into memory
     receive_pack_request = header + packfile
 
-    async with aiohttp.ClientSession(auth=auth) as session:
-        async with session.post(
+    async with (
+        aiohttp.ClientSession(auth=auth) as session,
+        session.post(
             url,
             headers={
                 "Content-type": "application/x-git-receive-pack-request",
             },
             data=receive_pack_request,
             raise_for_status=True,
-        ) as resp:
-            lines = decode_lines(iter_lines(resp, encoding="utf-8"))
-            unpack_status = await anext(lines)
-            if unpack_status != "unpack ok":
-                raise UnpackFailed(unpack_status)
+        ) as resp,
+    ):
+        lines = read_pkt_lines(resp.content)
+        unpack_status = await anext(lines)
+        if unpack_status != "unpack ok":
+            raise UnpackFailed(unpack_status)
 
-            # "ng <ref> <reason>" (ng = not good) means the remote rejected the
-            # update. The reason may be non-fast-forward, hook declined, etc.
-            ref_status = await anext(lines)
-            prefix = f"ng {ref} "
-            if ref_status.startswith(prefix):
-                reason_str = ref_status[len(prefix) :]
-                raise RefUpdateRejected(reason_str)
+        # "ng <ref> <reason>" (ng = not good) means the remote rejected the
+        # update. The reason may be non-fast-forward, hook declined, etc.
+        ref_status = await anext(lines)
+        prefix = f"ng {ref} "
+        if ref_status.startswith(prefix):
+            reason = ref_status[len(prefix) :]
+            raise RefUpdateRejected(reason)
 
-            if ref_status != f"ok {ref}":
-                raise UnexpectedResponse(f"unexpected ref status line: {ref_status!r}")
+        if ref_status != f"ok {ref}":
+            raise UnexpectedResponse(f"unexpected ref status line: {ref_status!r}")

--- a/src/repligit/asyncio/client.py
+++ b/src/repligit/asyncio/client.py
@@ -2,10 +2,9 @@ from collections.abc import Iterable
 
 import aiohttp
 
-from repligit.asyncio.parse import read_pkt_lines
+from repligit.asyncio.parse import read_packfile, read_pkt_lines
 from repligit.exceptions import (
     RefUpdateRejected,
-    RemoteError,
     UnexpectedResponse,
     UnpackFailed,
 )
@@ -66,20 +65,9 @@ async def fetch_pack(
             timeout=None,
         ) as resp,
     ):
-        length_bytes = await resp.content.readexactly(4)
-        line_length = int(length_bytes, 16)
-
-        line = await resp.content.readexactly(line_length - 4)
-
-        # e.g. "ERR upload-pack: not our ref <sha>"
-        if line[:3] == b"ERR":
-            raise RemoteError(line.decode("utf-8").strip())
-
-        if line[:3] in (b"NAK", b"ACK"):
-            # Unlike the sync version, the packfile must be read here, while
-            # the response is still open, and returned as bytes.
-            return await resp.content.read()
-        return None
+        # The packfile must be fully read within this async context so the
+        # caller can use it; read_packfile does so before returning.
+        return await read_packfile(resp.content)
 
 
 async def send_pack(

--- a/src/repligit/asyncio/parse.py
+++ b/src/repligit/asyncio/parse.py
@@ -1,51 +1,92 @@
-from typing import AsyncIterable, AsyncIterator
+import asyncio
+from collections.abc import AsyncIterator
 
 import aiohttp
 
+from repligit.exceptions import RemoteError, UnexpectedResponse
+from repligit.parse import parse_pkt_length
 
-async def decode_lines(line_stream: AsyncIterable) -> AsyncIterator:
-    """Decode git server response iterator into individual data lines.
 
-    This asynchronous function processes a stream of lines from a server response,
-    where each line is prefixed with a 4-character hexadecimal length indicator.
-    It extracts and yields the actual data portion of each line.
+async def _read_pkt_prefix(reader: aiohttp.StreamReader) -> bytes:
+    """Read the next 4-byte pkt-line length prefix.
 
-    Args:
-        line_stream: An asynchronous iterable providing the raw server response lines.
-
-    Yields:
-        The decoded data portion of each line, with the length prefix removed.
+    Returns ``b""`` at a clean end of stream. Raises ``UnexpectedResponse``
+    if the stream is truncated mid-prefix.
     """
-    async for line in line_stream:
-        line_length = int(line[:4], 16)
-        yield line[4:line_length]
+    try:
+        return await reader.readexactly(4)
+    except asyncio.IncompleteReadError as e:
+        if not e.partial:
+            return b""
+        raise UnexpectedResponse(
+            f"response truncated mid-pkt-line: {e.partial!r}"
+        ) from None
 
 
-async def iter_lines(
-    resp: aiohttp.ClientResponse, encoding: str = "utf-8", chunk_size: int = 16 * 1024
+async def _read_pkt_payload(
+    reader: aiohttp.StreamReader, line_length: int, encoding: str = "utf-8"
+) -> bytes:
+    """Read the payload of a pkt-line whose length prefix was already read.
+
+    Raises ``UnexpectedResponse`` if the stream is truncated mid-payload and
+    ``RemoteError`` if the payload is an ``ERR`` line (e.g. "ERR upload-pack:
+    not our ref <sha>").
+    """
+    payload_length = line_length - 4
+    try:
+        payload = await reader.readexactly(payload_length)
+    except asyncio.IncompleteReadError as e:
+        raise UnexpectedResponse(
+            f"response truncated mid-pkt-line: expected {payload_length} "
+            f"bytes, got {len(e.partial)}"
+        ) from None
+
+    if payload[:3] == b"ERR":
+        raise RemoteError(payload.decode(encoding).strip())
+
+    return payload
+
+
+async def read_pkt_lines(
+    reader: aiohttp.StreamReader, encoding: str = "utf-8"
 ) -> AsyncIterator[str]:
-    """
-    Asynchronously iterate over the lines of an HTTP response.
+    """Yield the decoded payload of each pkt-line from a git response stream.
+
+    This frames the stream by length exactly as the git pkt-line format
+    dictates rather than splitting on newlines, which is fragile: pkt-line
+    payloads may embed ``\\0`` (capabilities) and flush packets (``0000``)
+    carry no trailing newline. Each pkt-line is read as a 4-hex-digit length
+    prefix followed by ``length - 4`` payload bytes.
+
+    Flush packets (``0000``) are skipped. A single optional trailing ``LF`` is
+    stripped from each payload before it is decoded and yielded.
+
+    ``reader`` is an asynchronous byte stream exposing ``readexactly``
+    (e.g. ``aiohttp.ClientResponse.content``).
 
     Args:
-        resp: The aiohttp ClientResponse object to read from.
-        encoding: The character encoding to use for decoding bytes to strings.
-            Defaults to "utf-8".
-        chunk_size: The number of bytes to read in each chunk.
-            Defaults to 16 KiB (16 * 1024 bytes).
+        reader: The asynchronous response byte stream.
+        encoding: Character encoding used to decode payloads. Defaults to
+            "utf-8".
 
     Yields:
-        str: Each line from the response, with trailing carriage returns removed
-            and decoded using the specified encoding.
+        str: The decoded payload of each data pkt-line.
+
+    Raises:
+        RemoteError: If the server sends an ``ERR`` pkt-line.
+        UnexpectedResponse: If the stream is truncated mid-pkt-line or a
+            pkt-line is malformed.
     """
-    incomplete_line = bytearray()
+    while True:
+        prefix = await _read_pkt_prefix(reader)
+        if not prefix:
+            # Clean end of stream.
+            return
 
-    async for chunk in resp.content.iter_chunked(chunk_size):
-        lines = (incomplete_line + chunk).split(b"\n")
-        incomplete_line = lines.pop()
+        line_length = parse_pkt_length(prefix)
+        if line_length == 0:
+            # Flush packet ("0000"); carries no payload.
+            continue
 
-        for line in lines:
-            yield line.rstrip(b"\r").decode(encoding)
-
-    if incomplete_line:
-        yield incomplete_line.rstrip(b"\r").decode(encoding)
+        payload = await _read_pkt_payload(reader, line_length, encoding)
+        yield payload.removesuffix(b"\n").decode(encoding)

--- a/src/repligit/asyncio/parse.py
+++ b/src/repligit/asyncio/parse.py
@@ -47,6 +47,52 @@ async def _read_pkt_payload(
     return payload
 
 
+async def read_packfile(reader: aiohttp.StreamReader) -> bytes | None:
+    """Drain a git-upload-pack negotiation section and return the packfile.
+
+    ``reader`` is an asynchronous byte stream exposing ``readexactly`` and
+    ``read`` (e.g. ``aiohttp.ClientResponse.content``).
+
+    The server response begins with a negotiation section made up of pkt-lines
+    (``NAK``, ``ACK <sha>``, ``ACK <sha> <status>``, ``shallow <sha>``, ...).
+    The packfile that follows is *not* a pkt-line: it starts with the literal
+    4-byte ``PACK`` signature. Servers may send several pkt-lines (e.g. multiple
+    ``ACK`` lines during negotiation), so we consume pkt-lines until the
+    ``PACK`` signature is reached.
+
+    Args:
+        reader: The asynchronous response byte stream.
+
+    Returns:
+        bytes: The packfile, including its ``PACK`` signature.
+        None: If the stream ends before a packfile is sent.
+
+    Raises:
+        RemoteError: If the server sends an ``ERR`` pkt-line.
+        UnexpectedResponse: If the stream is truncated mid-pkt-line or a
+            pkt-line is malformed.
+    """
+    while True:
+        prefix = await _read_pkt_prefix(reader)
+
+        # The packfile is not length-prefixed; it begins with "PACK". This can
+        # never collide with a pkt-line length prefix, which is 4 hex digits.
+        if prefix == b"PACK":
+            return prefix + await reader.read()
+
+        if not prefix:
+            # Clean end of stream without a packfile (nothing to fetch).
+            return None
+
+        line_length = parse_pkt_length(prefix)
+        if line_length == 0:
+            # Flush packet ("0000"); keep draining.
+            continue
+
+        # NAK / ACK / shallow / unshallow -> keep draining the negotiation.
+        await _read_pkt_payload(reader, line_length)
+
+
 async def read_pkt_lines(
     reader: aiohttp.StreamReader, encoding: str = "utf-8"
 ) -> AsyncIterator[str]:

--- a/src/repligit/client.py
+++ b/src/repligit/client.py
@@ -1,6 +1,7 @@
 import urllib.request
+from collections.abc import Iterable
 from http.client import HTTPResponse
-from typing import BinaryIO, Iterable
+from typing import BinaryIO
 
 from repligit.exceptions import (
     RefUpdateRejected,
@@ -9,10 +10,9 @@ from repligit.exceptions import (
     UnpackFailed,
 )
 from repligit.parse import (
-    decode_lines,
     generate_fetch_pack_request,
     generate_send_pack_header,
-    iter_lines,
+    read_pkt_lines,
 )
 
 
@@ -64,12 +64,17 @@ def ls_remote(
 
     resp = http_request(url, username=username, password=password)
 
-    lines = decode_lines(iter_lines(resp))
+    lines = read_pkt_lines(resp)
     service_line = next(lines)
     if service_line != "# service=git-upload-pack":
         raise UnexpectedResponse(f"invalid service line: {service_line!r}")
 
-    return {ref: sha for sha, ref in (line.split() for line in lines if line)}
+    refs: dict[str, str] = {}
+    for line in lines:
+        # The first ref line carries the server capabilities after a NUL byte.
+        sha, ref = line.split("\x00", 1)[0].split()
+        refs[ref] = sha
+    return refs
 
 
 def fetch_pack(
@@ -103,10 +108,9 @@ def fetch_pack(
     if line[:3] == b"ERR":
         raise RemoteError(line.decode("utf-8").strip())
 
-    if line[:3] == b"NAK" or line[:3] == b"ACK":
+    if line[:3] in (b"NAK", b"ACK"):
         return resp
-    else:
-        return None
+    return None
 
 
 def send_pack(
@@ -134,7 +138,7 @@ def send_pack(
         data=receive_pack_request,
     )
 
-    lines = decode_lines(iter_lines(resp))
+    lines = read_pkt_lines(resp)
     unpack_status = next(lines)
     if unpack_status != "unpack ok":
         raise UnpackFailed(unpack_status)
@@ -144,8 +148,8 @@ def send_pack(
     ref_status = next(lines)
     prefix = f"ng {ref} "
     if ref_status.startswith(prefix):
-        reason_str = ref_status[len(prefix) :]
-        raise RefUpdateRejected(reason_str)
+        reason = ref_status[len(prefix) :]
+        raise RefUpdateRejected(reason)
 
     if ref_status != f"ok {ref}":
         raise UnexpectedResponse(f"unexpected ref status line: {ref_status!r}")

--- a/src/repligit/client.py
+++ b/src/repligit/client.py
@@ -5,13 +5,13 @@ from typing import BinaryIO
 
 from repligit.exceptions import (
     RefUpdateRejected,
-    RemoteError,
     UnexpectedResponse,
     UnpackFailed,
 )
 from repligit.parse import (
     generate_fetch_pack_request,
     generate_send_pack_header,
+    read_packfile,
     read_pkt_lines,
 )
 
@@ -83,7 +83,7 @@ def fetch_pack(
     have_shas: Iterable[str],
     username: str | None = None,
     password: str | None = None,
-) -> HTTPResponse | None:
+) -> BinaryIO | None:
     """Download a packfile from a remote server."""
     # ensure have_shas is a set, else packfile errors will occur
     have_shas = set(have_shas)
@@ -101,16 +101,14 @@ def fetch_pack(
         data=request,
     )
 
-    line_length = int(resp.read(4), 16)
-    line = resp.read(line_length - 4)
+    # read_packfile drains the negotiation section and returns a stream over
+    # the packfile (closing it closes the HTTP response), or None if the
+    # server sent no packfile.
+    packfile = read_packfile(resp)
+    if packfile is None:
+        resp.close()
 
-    # e.g. "ERR upload-pack: not our ref <sha>"
-    if line[:3] == b"ERR":
-        raise RemoteError(line.decode("utf-8").strip())
-
-    if line[:3] in (b"NAK", b"ACK"):
-        return resp
-    return None
+    return packfile
 
 
 def send_pack(

--- a/src/repligit/parse.py
+++ b/src/repligit/parse.py
@@ -1,52 +1,127 @@
-from typing import IO, Generator, Iterable, Set
+from collections.abc import Generator, Iterable
+from typing import IO
+
+from repligit.exceptions import RemoteError, UnexpectedResponse
 
 
-def iter_lines(
-    data: IO, encoding: str = "utf-8", chunk_size: int = 16 * 1024
+def parse_pkt_length(prefix: bytes) -> int:
+    """Parse and validate a 4-byte pkt-line length prefix.
+
+    Args:
+        prefix: The 4-byte hexadecimal length prefix of a pkt-line.
+
+    Returns:
+        int: The total pkt-line length. ``0`` denotes a flush packet.
+
+    Raises:
+        UnexpectedResponse: If the prefix is not hexadecimal or denotes an
+            impossible length (1-3 can never fit the 4-byte prefix itself).
+    """
+    try:
+        line_length = int(prefix, 16)
+    except ValueError:
+        raise UnexpectedResponse(f"invalid pkt-line length: {prefix!r}") from None
+
+    if 0 < line_length < 4:
+        raise UnexpectedResponse(f"invalid pkt-line length: {prefix!r}")
+
+    return line_length
+
+
+def _read_exact(stream: IO[bytes], n: int) -> bytes:
+    """Read exactly ``n`` bytes from ``stream``, or fewer at end of stream.
+
+    Loops over ``stream.read``, so it tolerates file-like objects whose
+    ``read`` may return fewer bytes than requested before end of stream.
+    """
+    data = bytearray()
+    while len(data) < n:
+        chunk = stream.read(n - len(data))
+        if not chunk:
+            break
+        data += chunk
+    return bytes(data)
+
+
+def _read_pkt_prefix(stream: IO[bytes]) -> bytes:
+    """Read the next 4-byte pkt-line length prefix.
+
+    Returns ``b""`` at a clean end of stream. Raises ``UnexpectedResponse``
+    if the stream is truncated mid-prefix.
+    """
+    prefix = _read_exact(stream, 4)
+    if prefix and len(prefix) < 4:
+        raise UnexpectedResponse(f"response truncated mid-pkt-line: {prefix!r}")
+    return prefix
+
+
+def _read_pkt_payload(
+    stream: IO[bytes], line_length: int, encoding: str = "utf-8"
+) -> bytes:
+    """Read the payload of a pkt-line whose length prefix was already read.
+
+    Raises ``UnexpectedResponse`` if the stream is truncated mid-payload and
+    ``RemoteError`` if the payload is an ``ERR`` line (e.g. "ERR upload-pack:
+    not our ref <sha>").
+    """
+    payload_length = line_length - 4
+    payload = _read_exact(stream, payload_length)
+    if len(payload) < payload_length:
+        raise UnexpectedResponse(
+            f"response truncated mid-pkt-line: expected {payload_length} "
+            f"bytes, got {len(payload)}"
+        )
+
+    if payload[:3] == b"ERR":
+        raise RemoteError(payload.decode(encoding).strip())
+
+    return payload
+
+
+def read_pkt_lines(
+    stream: IO[bytes], encoding: str = "utf-8"
 ) -> Generator[str, None, None]:
-    """
-    Iterate over the lines of a file-like object, yielding one line at a time.
+    """Yield the decoded payload of each pkt-line from a git response stream.
+
+    This frames the stream by length exactly as the git pkt-line format
+    dictates rather than splitting on newlines, which is fragile: pkt-line
+    payloads may embed ``\\0`` (capabilities) and flush packets (``0000``)
+    carry no trailing newline. Each pkt-line is read as a 4-hex-digit length
+    prefix followed by ``length - 4`` payload bytes.
+
+    Flush packets (``0000``) are skipped. A single optional trailing ``LF`` is
+    stripped from each payload before it is decoded and yielded.
+
+    ``stream`` is a synchronous, file-like byte stream (e.g.
+    ``http.client.HTTPResponse``). Short reads before end of stream are
+    tolerated.
 
     Args:
-        data: A file-like object with a read() method that returns bytes
-        encoding (str, optional): Character encoding to use for decoding bytes to strings.
+        stream: The response byte stream.
+        encoding (str, optional): Character encoding used to decode payloads.
             Defaults to "utf-8".
-        chunk_size (int, optional): Number of bytes to read in each chunk.
-            Defaults to 16 KiB.
 
     Yields:
-        str: Each line from the input data, with line endings removed.
+        str: The decoded payload of each data pkt-line.
+
+    Raises:
+        RemoteError: If the server sends an ``ERR`` pkt-line.
+        UnexpectedResponse: If the stream is truncated mid-pkt-line or a
+            pkt-line is malformed.
     """
-    incomplete_line = bytearray()
+    while True:
+        prefix = _read_pkt_prefix(stream)
+        if not prefix:
+            # Clean end of stream.
+            return
 
-    for chunk in iter(lambda: data.read(chunk_size), b""):
-        lines = (incomplete_line + chunk).split(b"\n")
-        incomplete_line = lines.pop()
+        line_length = parse_pkt_length(prefix)
+        if line_length == 0:
+            # Flush packet ("0000"); carries no payload.
+            continue
 
-        for line in lines:
-            yield line.rstrip(b"\r").decode(encoding)
-
-    if incomplete_line:
-        yield incomplete_line.rstrip(b"\r").decode(encoding)
-
-
-def decode_lines(lines: Iterable[str]) -> Generator[str, None, None]:
-    """
-    Decode lines from the git transfer protocol into usable lines.
-
-    This asynchronous function processes a stream of lines from a server response,
-    where each line is prefixed with a 4-character hexadecimal length indicator.
-    It extracts and yields the actual data portion of each line.
-
-    Args:
-        lines: A generator yielding strings from a git server response.
-
-    Yields:
-        str: Decoded content from each line with the length prefix removed.
-    """
-    for line in lines:
-        line_length = int(line[:4], 16)
-        yield line[4:line_length]
+        payload = _read_pkt_payload(stream, line_length, encoding)
+        yield payload.removesuffix(b"\n").decode(encoding)
 
 
 def encode_lines(lines: Iterable[bytes | str]) -> bytes:
@@ -86,7 +161,7 @@ def generate_send_pack_header(ref: str, from_sha: str, to_sha: str) -> bytes:
     return encode_lines([f"{from_sha} {to_sha} {ref}\x00 report-status"]) + b"0000"
 
 
-def generate_fetch_pack_request(want: str, haves: Set[str]) -> bytes:
+def generate_fetch_pack_request(want: str, haves: set[str]) -> bytes:
     """Generate a git-upload packfile request.
 
     Args:

--- a/src/repligit/parse.py
+++ b/src/repligit/parse.py
@@ -1,5 +1,6 @@
+import io
 from collections.abc import Generator, Iterable
-from typing import IO
+from typing import IO, BinaryIO
 
 from repligit.exceptions import RemoteError, UnexpectedResponse
 
@@ -143,6 +144,90 @@ def encode_lines(lines: Iterable[bytes | str]) -> bytes:
         result.append(b"\n")
 
     return b"".join(result)
+
+
+class _PackfileStream(io.RawIOBase):
+    """Read-only binary stream that replays the already-consumed ``PACK``
+    signature before delegating reads to the underlying response stream.
+
+    This lets ``read_packfile`` hand the packfile back to the caller as a
+    stream without buffering it in memory. Closing this stream closes the
+    underlying stream.
+    """
+
+    def __init__(self, stream: IO[bytes]):
+        self._stream = stream
+        self._prefix = b"PACK"
+
+    def readable(self) -> bool:
+        return True
+
+    def readinto(self, buffer) -> int:
+        # Serve the replayed signature first, then pass reads through.
+        if self._prefix:
+            n = min(len(buffer), len(self._prefix))
+            buffer[:n] = self._prefix[:n]
+            self._prefix = self._prefix[n:]
+            return n
+
+        chunk = self._stream.read(len(buffer))
+        buffer[: len(chunk)] = chunk
+        return len(chunk)
+
+    def close(self) -> None:
+        try:
+            self._stream.close()
+        finally:
+            super().close()
+
+
+def read_packfile(stream: IO[bytes]) -> BinaryIO | None:
+    """Drain a git-upload-pack negotiation section and return the packfile.
+
+    ``stream`` is a synchronous, file-like byte stream (e.g.
+    ``http.client.HTTPResponse``).
+
+    The server response begins with a negotiation section made up of pkt-lines
+    (``NAK``, ``ACK <sha>``, ``ACK <sha> <status>``, ``shallow <sha>``, ...).
+    The packfile that follows is *not* a pkt-line: it starts with the literal
+    4-byte ``PACK`` signature. Servers may send several pkt-lines (e.g. multiple
+    ``ACK`` lines during negotiation), so we consume pkt-lines until the
+    ``PACK`` signature is reached.
+
+    Args:
+        stream: The response byte stream.
+
+    Returns:
+        BinaryIO: A read-only stream over the packfile, starting at its
+            ``PACK`` signature. The packfile is *not* buffered in memory;
+            reads are forwarded to ``stream``, and closing the returned
+            stream closes ``stream``.
+        None: If the stream ends before a packfile is sent.
+
+    Raises:
+        RemoteError: If the server sends an ``ERR`` pkt-line.
+        UnexpectedResponse: If the stream is truncated mid-pkt-line or a
+            pkt-line is malformed.
+    """
+    while True:
+        prefix = _read_pkt_prefix(stream)
+
+        # The packfile is not length-prefixed; it begins with "PACK". This can
+        # never collide with a pkt-line length prefix, which is 4 hex digits.
+        if prefix == b"PACK":
+            return io.BufferedReader(_PackfileStream(stream))
+
+        if not prefix:
+            # Clean end of stream without a packfile (nothing to fetch).
+            return None
+
+        line_length = parse_pkt_length(prefix)
+        if line_length == 0:
+            # Flush packet ("0000"); keep draining.
+            continue
+
+        # NAK / ACK / shallow / unshallow -> keep draining the negotiation.
+        _read_pkt_payload(stream, line_length)
 
 
 def generate_send_pack_header(ref: str, from_sha: str, to_sha: str) -> bytes:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -5,11 +5,13 @@ from typing import cast
 import aiohttp
 import pytest
 
+from repligit.asyncio.parse import read_packfile as async_read_packfile
 from repligit.asyncio.parse import read_pkt_lines as async_read_pkt_lines
 from repligit.exceptions import RemoteError, UnexpectedResponse
 from repligit.parse import (
     encode_lines,
     generate_send_pack_header,
+    read_packfile,
     read_pkt_lines,
 )
 
@@ -18,6 +20,9 @@ def _pkt(payload: bytes) -> bytes:
     """Encode a single git pkt-line."""
     return f"{len(payload) + 5:04x}".encode() + payload + b"\n"
 
+
+# A minimal but valid packfile body: "PACK", version 2, zero objects, trailer.
+FAKE_PACK = b"PACK\x00\x00\x00\x02\x00\x00\x00\x00" + b"\x00" * 20
 
 SHA_A = "a" * 40
 SHA_B = "b" * 40
@@ -36,9 +41,19 @@ class _AsyncStream:
         chunk, self._buf = self._buf[:n], self._buf[n:]
         return chunk
 
+    async def read(self, n: int = -1) -> bytes:
+        if n < 0:
+            n = len(self._buf)
+        chunk, self._buf = self._buf[:n], self._buf[n:]
+        return chunk
+
 
 def _async_stream(data: bytes) -> aiohttp.StreamReader:
     return cast(aiohttp.StreamReader, _AsyncStream(data))
+
+
+def _read_packfile_async(data: bytes) -> bytes | None:
+    return asyncio.run(async_read_packfile(_async_stream(data)))
 
 
 def _collect_async_pkt_lines(raw: bytes) -> list[str]:
@@ -48,7 +63,103 @@ def _collect_async_pkt_lines(raw: bytes) -> list[str]:
     return asyncio.run(_collect())
 
 
+# Responses exercised by both the sync and async read_packfile helpers.
+_PACKFILE_CASES = [
+    # Single NAK line immediately followed by the pack.
+    pytest.param(_pkt(b"NAK") + FAKE_PACK, FAKE_PACK, id="nak"),
+    # Single terminal ACK line followed by the pack.
+    pytest.param(_pkt(f"ACK {SHA_A}".encode()) + FAKE_PACK, FAKE_PACK, id="single_ack"),
+    # Regression: multiple ACK lines precede the pack (multi-ack negotiation as
+    # emitted by GitHub/GitLab). Previously only the first line was consumed,
+    # leaving "ACK ..." bytes in front of the pack and corrupting its signature.
+    pytest.param(
+        _pkt(f"ACK {SHA_A} common".encode())
+        + _pkt(f"ACK {SHA_B} common".encode())
+        + _pkt(f"ACK {SHA_B}".encode())
+        + FAKE_PACK,
+        FAKE_PACK,
+        id="multi_ack",
+    ),
+    # Shallow lines and a flush packet precede the pack.
+    pytest.param(
+        _pkt(f"shallow {SHA_A}".encode()) + b"0000" + _pkt(b"NAK") + FAKE_PACK,
+        FAKE_PACK,
+        id="shallow_and_flush",
+    ),
+    # Negotiation only, no packfile (stream ends): returns None.
+    pytest.param(_pkt(b"NAK"), None, id="no_pack"),
+]
+
 _ERR_RESPONSE = _pkt(b"ERR upload-pack: not our ref " + SHA_A.encode())
+
+# Malformed or truncated responses that must raise UnexpectedResponse rather
+# than being silently misread as "no packfile".
+_BAD_RESPONSES = [
+    # Connection dropped mid-length-prefix.
+    pytest.param(_pkt(b"NAK") + b"00", id="truncated_prefix"),
+    # Connection dropped mid-pkt-line payload.
+    pytest.param(_pkt(f"ACK {SHA_A}".encode())[:20], id="truncated_line"),
+    # Length prefix is not hex (and not "PACK").
+    pytest.param(b"zzzz" + FAKE_PACK, id="garbage_prefix"),
+    # Lengths 1-3 can never denote a valid pkt-line in this response.
+    pytest.param(b"0002" + _pkt(b"NAK") + FAKE_PACK, id="bogus_length"),
+]
+
+
+@pytest.mark.parametrize("raw,expected", _PACKFILE_CASES)
+def test_read_packfile_sync(raw, expected):
+    stream = read_packfile(io.BytesIO(raw))
+    if expected is None:
+        assert stream is None
+    else:
+        assert stream is not None
+        assert stream.read() == expected
+
+
+def test_read_packfile_sync_streams_incrementally():
+    """The consumed PACK signature is replayed and reads pass through."""
+    stream = read_packfile(io.BytesIO(_pkt(b"NAK") + FAKE_PACK))
+    assert stream is not None
+    assert stream.read(2) == b"PA"
+    assert stream.read(6) == b"CK\x00\x00\x00\x02"
+    assert stream.read() == FAKE_PACK[8:]
+    assert stream.read() == b""
+
+
+def test_read_packfile_sync_close_propagates():
+    """Closing the packfile stream closes the underlying response stream."""
+    underlying = io.BytesIO(_pkt(b"NAK") + FAKE_PACK)
+    stream = read_packfile(underlying)
+    assert stream is not None
+    stream.close()
+    assert underlying.closed
+
+
+@pytest.mark.parametrize("raw,expected", _PACKFILE_CASES)
+def test_read_packfile_async(raw, expected):
+    assert _read_packfile_async(raw) == expected
+
+
+def test_read_packfile_sync_raises_on_err():
+    with pytest.raises(RemoteError):
+        read_packfile(io.BytesIO(_ERR_RESPONSE))
+
+
+def test_read_packfile_async_raises_on_err():
+    with pytest.raises(RemoteError):
+        _read_packfile_async(_ERR_RESPONSE)
+
+
+@pytest.mark.parametrize("raw", _BAD_RESPONSES)
+def test_read_packfile_sync_raises_on_malformed(raw):
+    with pytest.raises(UnexpectedResponse):
+        read_packfile(io.BytesIO(raw))
+
+
+@pytest.mark.parametrize("raw", _BAD_RESPONSES)
+def test_read_packfile_async_raises_on_malformed(raw):
+    with pytest.raises(UnexpectedResponse):
+        _read_packfile_async(raw)
 
 
 # A realistic git-upload-pack ref advertisement. Note the flush packet after

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,21 +1,124 @@
-from repligit.parse import decode_lines, encode_lines, generate_send_pack_header
+import asyncio
+import io
+from typing import cast
+
+import aiohttp
+import pytest
+
+from repligit.asyncio.parse import read_pkt_lines as async_read_pkt_lines
+from repligit.exceptions import RemoteError, UnexpectedResponse
+from repligit.parse import (
+    encode_lines,
+    generate_send_pack_header,
+    read_pkt_lines,
+)
 
 
-def test_decode_lines():
-    raw_lines = [
-        "003fbef547a59eec448284136f03984dce0f2f8239a9 refs/pull/95/head",
-        "003f358aa046cd57dbca306e80d4c3fbb86edc5b36af refs/pull/96/head",
-        "0000",
-    ]
+def _pkt(payload: bytes) -> bytes:
+    """Encode a single git pkt-line."""
+    return f"{len(payload) + 5:04x}".encode() + payload + b"\n"
 
-    decoded_lines = [
-        "bef547a59eec448284136f03984dce0f2f8239a9 refs/pull/95/head",
-        "358aa046cd57dbca306e80d4c3fbb86edc5b36af refs/pull/96/head",
-        "",
-    ]
 
-    lines = list(decode_lines(raw_lines))
-    assert decoded_lines == lines
+SHA_A = "a" * 40
+SHA_B = "b" * 40
+
+
+class _AsyncStream:
+    """Minimal async byte reader mimicking aiohttp's StreamReader."""
+
+    def __init__(self, data: bytes):
+        self._buf = data
+
+    async def readexactly(self, n: int) -> bytes:
+        if len(self._buf) < n:
+            partial, self._buf = self._buf, b""
+            raise asyncio.IncompleteReadError(partial, n)
+        chunk, self._buf = self._buf[:n], self._buf[n:]
+        return chunk
+
+
+def _async_stream(data: bytes) -> aiohttp.StreamReader:
+    return cast(aiohttp.StreamReader, _AsyncStream(data))
+
+
+def _collect_async_pkt_lines(raw: bytes) -> list[str]:
+    async def _collect() -> list[str]:
+        return [line async for line in async_read_pkt_lines(_async_stream(raw))]
+
+    return asyncio.run(_collect())
+
+
+_ERR_RESPONSE = _pkt(b"ERR upload-pack: not our ref " + SHA_A.encode())
+
+
+# A realistic git-upload-pack ref advertisement. Note the flush packet after
+# the service line carries no trailing newline, and the first ref line embeds
+# the server capabilities after a NUL byte.
+_ADVERTISEMENT = (
+    _pkt(b"# service=git-upload-pack")
+    + b"0000"
+    + _pkt(
+        f"{SHA_A} HEAD\x00multi_ack thin-pack side-band-64k "
+        f"symref=HEAD:refs/heads/main".encode()
+    )
+    + _pkt(f"{SHA_A} refs/heads/main".encode())
+    + _pkt(f"{SHA_B} refs/tags/v1".encode())
+    + b"0000"
+)
+
+_ADVERTISEMENT_LINES = [
+    "# service=git-upload-pack",
+    f"{SHA_A} HEAD\x00multi_ack thin-pack side-band-64k symref=HEAD:refs/heads/main",
+    f"{SHA_A} refs/heads/main",
+    f"{SHA_B} refs/tags/v1",
+]
+
+
+def test_read_pkt_lines_frames_by_length_sync():
+    # Flush packets are skipped and one trailing LF is stripped per payload.
+    lines = list(read_pkt_lines(io.BytesIO(_ADVERTISEMENT)))
+    assert lines == _ADVERTISEMENT_LINES
+
+
+def test_read_pkt_lines_frames_by_length_async():
+    assert _collect_async_pkt_lines(_ADVERTISEMENT) == _ADVERTISEMENT_LINES
+
+
+# Malformed or truncated pkt-line streams that must raise UnexpectedResponse
+# rather than yielding truncated or garbage lines.
+_BAD_PKT_STREAMS = [
+    # Connection dropped mid-length-prefix.
+    pytest.param(_pkt(b"unpack ok") + b"00", id="truncated_prefix"),
+    # Connection dropped mid-pkt-line payload.
+    pytest.param(_pkt(b"unpack ok")[:8], id="truncated_payload"),
+    # Length prefix is not hex.
+    pytest.param(b"zzzz" + _pkt(b"unpack ok"), id="garbage_prefix"),
+    # Lengths 1-3 can never fit the 4-byte prefix itself. Notably, "0002"
+    # previously triggered read(-2), swallowing the rest of the stream.
+    pytest.param(b"0002" + _pkt(b"unpack ok"), id="bogus_length"),
+]
+
+
+@pytest.mark.parametrize("raw", _BAD_PKT_STREAMS)
+def test_read_pkt_lines_sync_raises_on_malformed(raw):
+    with pytest.raises(UnexpectedResponse):
+        list(read_pkt_lines(io.BytesIO(raw)))
+
+
+@pytest.mark.parametrize("raw", _BAD_PKT_STREAMS)
+def test_read_pkt_lines_async_raises_on_malformed(raw):
+    with pytest.raises(UnexpectedResponse):
+        _collect_async_pkt_lines(raw)
+
+
+def test_read_pkt_lines_sync_raises_on_err():
+    with pytest.raises(RemoteError):
+        list(read_pkt_lines(io.BytesIO(_ERR_RESPONSE)))
+
+
+def test_read_pkt_lines_async_raises_on_err():
+    with pytest.raises(RemoteError):
+        _collect_async_pkt_lines(_ERR_RESPONSE)
 
 
 def test_encode_lines_from_bytes():


### PR DESCRIPTION
Depends on #213 

fetch_pack previously consumed only the first negotiation pkt-line (NAK/ACK) before handing the rest of the response to the caller. With multi-ack negotiation (as emitted by GitHub/GitLab on complex PR branches) the remaining ACK lines were left in front of the packfile, corrupting its signature.

Add read_packfile, which drains all negotiation pkt-lines (NAK, ACK, shallow, flush) until the literal PACK signature is reached. The sync client now returns a stream over the packfile instead of the raw HTTP response, without buffering it in memory.