### PR TITLE
Mirror tags and branches with already mirrored refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ def main():
 
     from_sha = gl_refs.get(target_ref) or ("0" * 40)
 
-    if want_sha in have_shas:
+    if from_sha == want_sha:
         print("Everything is up to date")
         return
 

--- a/examples/git_mirror.py
+++ b/examples/git_mirror.py
@@ -27,7 +27,7 @@ def main():
 
     from_sha = gl_refs.get(target_ref) or ("0" * 40)
 
-    if want_sha in have_shas:
+    if from_sha == want_sha:
         print("Everything is up to date")
         return
 

--- a/examples/git_mirror_async.py
+++ b/examples/git_mirror_async.py
@@ -31,7 +31,7 @@ async def main():
 
     from_sha = gl_refs.get(target_ref) or ("0" * 40)
 
-    if want_sha in have_shas:
+    if from_sha == want_sha:
         print("Everything is up to date")
         return
 


### PR DESCRIPTION
Realized the previous way we were telling folks to use repligit was incorrect for tags and branches that already map to a known ref