### PR TITLE
Use hatch-vcs to dynamically render version from git tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,7 @@ jobs:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
       with:
         persist-credentials: false
+        fetch-depth: 0
 
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97

--- a/.github/workflows/requirements/publish.txt
+++ b/.github/workflows/requirements/publish.txt
@@ -1,2 +1,3 @@
 hatchling==1.31.0
+hatch-vcs==0.5.0
 build==1.5.0

--- a/.github/workflows/requirements/unit-tests.txt
+++ b/.github/workflows/requirements/unit-tests.txt
@@ -1,4 +1,5 @@
 hatchling==1.31.0
+hatch-vcs==0.5.0
 build==1.5.0
 pytest==9.0.2
 pytest-mock==3.15.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "repligit"
-version = "0.3.0"
-dependencies = []
+dynamic = ["version"]
 authors = [
   { name="Alec Scott" },
   { name="Caetano Melone"},
@@ -26,6 +25,9 @@ Issues = "https://github.com/llnl/repligit/issues"
 [project.optional-dependencies]
 aiohttp = ["aiohttp"]
 dev = ["ty", "ruff", "typos", "coverage", "pytest", "pytest-mock"]
+
+[tool.hatch.version]
+source = "vcs"
 
 [tool.pytest.ini_options]
 pythonpath = [

--- a/spack.yaml
+++ b/spack.yaml
@@ -13,6 +13,8 @@ spack:
   - py-ruff
   - py-pip
   - py-ty
+  - py-build
+  - py-hatch-vcs
   view: true
   concretizer:
     unify: true

--- a/spack/repos/spack_repo/repligit/packages/py_repligit/package.py
+++ b/spack/repos/spack_repo/repligit/packages/py_repligit/package.py
@@ -28,5 +28,6 @@ class PyRepligit(PythonPackage):
 
     depends_on("python@3.10:", type=("build", "run"))
     depends_on("py-hatchling", type="build")
+    depends_on("py-hatch-vcs", type="build", when="@main")
 
     depends_on("py-aiohttp", type=("build", "run"), when="+aiohttp")


### PR DESCRIPTION
Instead of having to remember to always bump the version in `pyproject.toml` let's instead use the git tag as the version when publishing to PyPi.